### PR TITLE
Add linux, and preliminary mac, support

### DIFF
--- a/+neuron/Neuron.m
+++ b/+neuron/Neuron.m
@@ -24,13 +24,12 @@ classdef Neuron < dynamicprops
         %   fill_dynamic_props()
             arr = split(clib.neuron.get_nrn_functions(), ";");
             call_list = arr(1:end-1);
-            self.fn_void_list = string.empty;  % Empty, unless file is loaded.
 
             % Reset dynamic method lists.
-            self.fn_double_list = [];
-            self.fn_void_list = [];
-            self.fn_string_list = [];
-            self.object_list = [];
+            self.fn_double_list = string.empty;
+            self.fn_void_list = string.empty;
+            self.fn_string_list = string.empty;
+            self.object_list = string.empty;
 
             % Add dynamic properties.
             % See: doc/DEV_README.md#neuron-types

--- a/+tests/test_base_functionality.m
+++ b/+tests/test_base_functionality.m
@@ -1,31 +1,31 @@
 classdef test_base_functionality < matlab.unittest.TestCase
 
     properties
-        tol = 1e-4;
+        tol = 1e-10;
     end
     
     methods(Test)
         % Test methods
         
-        function test_run(test)
+        function test_run(testCase)
             example_run;
-            assert(abs(n.t - 0.025) < test.tol);
+            testCase.verifyEqual(n.t, 0.025, "RelTol", testCase.tol);
         end
         
-        function test_vector(test)
+        function test_vector(testCase)
             % Example to run.
             example_vector;
             % Asserts for first vector.
-            assert(isa(v, "neuron.Vector"));
-            assert(abs(length(v) - 11) < test.tol);
-            assert(abs(v(2) - 0.025) < test.tol);
-            assert(abs(v(3) - 42) < test.tol);
-            assert(abs(v(11) - 5) < test.tol);
+            testCase.verifyClass(v, "neuron.Vector");
+            testCase.verifyEqual(length(v), 11);
+            testCase.verifyEqual(v(2), 0.025, "RelTol", testCase.tol);
+            testCase.verifyEqual(v(3), 42, "RelTol", testCase.tol);
+            testCase.verifyEqual(v(11), 5, "RelTol", testCase.tol);
             % Asserts for second vector.
-            assert(isa(v2, "neuron.Vector"));
-            assert(abs(length(v2) - 6) < test.tol);
-            assert(abs(v2(2) - 1) < test.tol);
-            assert(abs(v2(6) - 5.3) < test.tol);
+            testCase.verifyClass(v2, "neuron.Vector");
+            testCase.verifyEqual(length(v2), 6);
+            testCase.verifyEqual(v2(2), 1, "RelTol", testCase.tol);
+            testCase.verifyEqual(v2(6), 5.3, "RelTol", testCase.tol);
         end
 
     end

--- a/+tests/test_init.m
+++ b/+tests/test_init.m
@@ -3,12 +3,12 @@ classdef test_init < matlab.unittest.TestCase
     methods(Test)
         % Test methods
         
-        function test_neuron_initialization(~)
+        function test_neuron_initialization(testCase)
             % Initialize Neuron.
             n = neuron.Neuron();
             % Check Neuron interface object.
-            assert(isa(n, "neuron.Neuron"));
-            assert(isprop(n, 't'));
+            testCase.verifyClass(n, "neuron.Neuron");
+            testCase.verifyTrue(isprop(n, 't'));
         end
 
     end

--- a/+tests/test_input.m
+++ b/+tests/test_input.m
@@ -1,23 +1,23 @@
 classdef test_input < matlab.unittest.TestCase
 
     properties
-        tol = 1e-4;
+        tol = 1e-10;
     end
     
     methods(Test)
         
-        function test_loadfile(test)
+        function test_loadfile(testCase)
             example_loadfile;
-            assert(any(strcmp(n.fn_void_list, 'continuerun')));
-            assert(abs(n.t - 5) < test.tol);
+            testCase.verifyTrue(any(strcmp(n.fn_void_list, 'continuerun')));
+            testCase.verifyEqual(n.t, 5, "RelTol", testCase.tol);
         end
         
-        function test_mod(test)
+        function test_mod(testCase)
             example_mod;
-            assert(any(strcmp(axon.mech_list, "hd")));
-            assert(abs(syn.Alpha - 0.0720) < test.tol);
-            assert(abs(syn.Beta - 0.0066) < test.tol);
-            assert(abs(syn.e - 42) < test.tol);
+            testCase.verifyTrue(any(strcmp(axon.mech_list, "hd")));
+            testCase.verifyEqual(syn.Alpha, 0.0720, "RelTol", testCase.tol);
+            testCase.verifyEqual(syn.Beta, 0.0066, "RelTol", testCase.tol);
+            testCase.verifyEqual(syn.e, 42, "RelTol", testCase.tol);
         end
 
     end

--- a/+tests/test_morphology.m
+++ b/+tests/test_morphology.m
@@ -1,38 +1,38 @@
 classdef test_morphology < matlab.unittest.TestCase
 
     properties
-        tol = 1e-4;
+        tol = 1e-10;
     end
     
     methods(Test)
         % Test methods
         
-        function test_allsec(test)
+        function test_allsec(testCase)
             % Call the function to test
             example_allsec;
             % Check output.
-            assert(isa(sl, "neuron.Object"));
-            assert(sl.objtype == "SectionList");
-            assert(isa(axon2_new, "neuron.Section"));
-            assert(axon2_new.name == "axon2");
-            assert(abs(axon2_new.length - 42) < test.tol);
-            assert(isa(soma_new, "neuron.Section"));
-            assert(abs(soma_new.length - 100) < test.tol);
-            assert(soma_new.nseg == 5);
-            assert(soma_new.name == "soma");
-            assert(isa(soma_segs{1}, "neuron.Segment"));
-            assert(soma_segs{1}.parent_name == "soma");
-            assert(numel(soma_segs) == soma_new.nseg);
+            testCase.verifyClass(sl, "neuron.Object");
+            testCase.verifyEqual(sl.objtype, "SectionList");
+            testCase.verifyClass(axon2_new, "neuron.Section");
+            testCase.verifyEqual(axon2_new.name, "axon2");
+            testCase.verifyEqual(axon2_new.length, 42);
+            testCase.verifyClass(soma_new, "neuron.Section");
+            testCase.verifyEqual(soma_new.length, 100);
+            testCase.verifyEqual(double(soma_new.nseg), 5);
+            testCase.verifyEqual(soma_new.name, "soma");
+            testCase.verifyClass(soma_segs{1}, "neuron.Segment");
+            testCase.verifyEqual(soma_segs{1}.parent_name, "soma");
+            testCase.verifyEqual(numel(soma_segs), double(soma_new.nseg));
         end
 
-        function test_morph(test)
+        function test_morph(testCase)
             % Call the function to test
             example_morph;
             % Check output.
-            assert(abs(main.length - 200) < test.tol);
-            assert(main.nseg == 3);
-            assert(abs(iclamp.dur - 10000) < test.tol);
-            assert(~exist('branch2', 'var'));
+            testCase.verifyEqual(main.length, 200);
+            testCase.verifyEqual(double(main.nseg), 3);
+            testCase.verifyEqual(iclamp.dur, 10000);
+            testCase.verifyTrue(~exist('branch2', 'var'));
         end
     end
     

--- a/+tests/test_plotting.m
+++ b/+tests/test_plotting.m
@@ -1,30 +1,30 @@
 classdef test_plotting < matlab.unittest.TestCase
 
     properties
-        tol = 1e-4;
+        tol = 1e-10;
     end
     
     methods(Test)
         
-        function test_plotshape(~)
+        function test_plotshape(testCase)
             set(0,'DefaultFigureVisible','off');
             example_plotshape;
             plot_data_some = ps_some.get_plot_data();
-            assert(plot_data_some{1}.x(2) == 3);
-            assert(plot_data_some{end}.line_width == 2);
+            testCase.verifyEqual(plot_data_some{1}.x(2), 3);
+            testCase.verifyEqual(plot_data_some{end}.line_width, 2);
             plot_data_all = ps_all.get_plot_data();
-            assert(plot_data_all{16}.y(2) == 2.5);
-            assert(plot_data_all{end}.line_width == 3);
+            testCase.verifyEqual(plot_data_all{16}.y(2), 2.5);
+            testCase.verifyEqual(plot_data_all{end}.line_width, 3);
             set(0,'DefaultFigureVisible','on');
         end
         
-        function test_rangevarplot(test)
+        function test_rangevarplot(testCase)
             set(0,'DefaultFigureVisible','off');
             example_rangevarplot;
             [x, y] = rvp.get_xy_data();
-            assert(abs(x(2) - 0.0314) < test.tol);
-            assert(abs(x(end) - 6.28) < test.tol);
-            assert(abs(y(50) - 0.0956) < test.tol);
+            testCase.verifyEqual(x(2), 0.0314, "RelTol", testCase.tol);
+            testCase.verifyEqual(x(end), 6.28, "RelTol", testCase.tol);
+            testCase.verifyEqual(y(50), 0.0956, "RelTol", testCase.tol);
             set(0,'DefaultFigureVisible','on');
         end
 

--- a/+tests/test_plotting.m
+++ b/+tests/test_plotting.m
@@ -2,6 +2,7 @@ classdef test_plotting < matlab.unittest.TestCase
 
     properties
         tol = 1e-10;
+        tol_large = 1e-6;
     end
     
     methods(Test)
@@ -22,9 +23,10 @@ classdef test_plotting < matlab.unittest.TestCase
             set(0,'DefaultFigureVisible','off');
             example_rangevarplot;
             [x, y] = rvp.get_xy_data();
-            testCase.verifyEqual(x(2), 0.0314, "RelTol", testCase.tol);
-            testCase.verifyEqual(x(end), 6.28, "RelTol", testCase.tol);
-            testCase.verifyEqual(y(50), 0.0956, "RelTol", testCase.tol);
+            % RangeVarPlot.to_vector() returns values with ~1e-7 error; not sure why.
+            testCase.verifyEqual(x(2), 0.0314, "RelTol", testCase.tol_large);
+            testCase.verifyEqual(x(end), 6.28, "RelTol", testCase.tol_large);
+            testCase.verifyEqual(y(50), 0.0956462181823123, "RelTol", testCase.tol);
             set(0,'DefaultFigureVisible','on');
         end
 

--- a/+tests/test_simulation.m
+++ b/+tests/test_simulation.m
@@ -2,6 +2,7 @@ classdef test_simulation < matlab.unittest.TestCase
 
     properties
         tol = 1e-10;
+        tol_large = 1e-4;
     end
     
     methods(Test)
@@ -10,42 +11,44 @@ classdef test_simulation < matlab.unittest.TestCase
             set(0,'DefaultFigureVisible','off');
             example_acpot;
             set(0,'DefaultFigureVisible','on');
-            testCase.verifyEqual(v2_vec(100), 8.8916, "RelTol", testCase.tol);
-            testCase.verifyEqual(v1_vec(100), 3.7727, "RelTol", testCase.tol);
+            testCase.verifyEqual(v2_vec(100), 8.89159427501637, "RelTol", testCase.tol);
+            testCase.verifyEqual(v1_vec(100), 3.77273092993764, "RelTol", testCase.tol);
             testCase.verifyEqual(t_vec(100), 2.4750, "RelTol", testCase.tol);
         end
 
         function test_alphasynapse(testCase)
             example_alphasynapse;
-            testCase.verifyEqual(ivec(43), -1.9125, "RelTol", testCase.tol);
-            testCase.verifyEqual(v(101), 28.7358, "RelTol", testCase.tol);
+            testCase.verifyEqual(ivec(43), -1.91249419654768, "RelTol", testCase.tol);
+            testCase.verifyEqual(v(101), 28.7358157812159, "RelTol", testCase.tol);
         end
 
         function test_clamps(testCase)
             example_clamps;
-            testCase.verifyEqual(c2i_0, -8.5728e-06, "RelTol", testCase.tol);
-            testCase.verifyEqual(c3i_0, 6.0899e-06, "RelTol", testCase.tol);
-            testCase.verifyEqual(s2v_0, -65.0000, "RelTol", testCase.tol);
-            testCase.verifyEqual(s3v_0, -64.9987, "RelTol", testCase.tol);
-            testCase.verifyEqual(c2i_1, -1.7144e-05, "RelTol", testCase.tol);
-            testCase.verifyEqual(c3i_1, -65.0000, "RelTol", testCase.tol);
-            testCase.verifyEqual(s2v_1, -65.0000, "RelTol", testCase.tol);
-            testCase.verifyEqual(s3v_1, -64.9975, "RelTol", testCase.tol);
+            % In this example we use VClamp in a non-recommended way; as a
+            % result some test tolerances need to be increased.
+            testCase.verifyEqual(c2i_0, -8.57284021549276e-06, "RelTol", testCase.tol);
+            testCase.verifyEqual(c3i_0, 6.08992178285916e-06, "RelTol", testCase.tol);
+            testCase.verifyEqual(s2v_0, -65, "RelTol", testCase.tol_large);
+            testCase.verifyEqual(s3v_0, -64.9975, "RelTol", testCase.tol_large);
+            testCase.verifyEqual(c2i_1, -1.71437434914878e-05, "RelTol", testCase.tol);
+            testCase.verifyEqual(c3i_1, -65, "RelTol", testCase.tol_large);
+            testCase.verifyEqual(s2v_1, -65, "RelTol", testCase.tol_large);
+            testCase.verifyEqual(s3v_1, -64.9975, "RelTol", testCase.tol_large);
         end
 
         function test_intfires(testCase)
             example_intfires;
             testCase.verifyEqual(length(cell1out), 0);
             testCase.verifyEqual(length(cell2out), 2);
-            testCase.verifyEqual(cell2out(1), 7.5365, "RelTol", testCase.tol);
-            testCase.verifyEqual(cell2out(2), 16.1599, "RelTol", testCase.tol);
+            testCase.verifyEqual(cell2out(1), 7.53652449434298, "RelTol", testCase.tol);
+            testCase.verifyEqual(cell2out(2), 16.1598979699204, "RelTol", testCase.tol);
         end
 
         function test_linearmechanism(testCase)
             example_linearmechanism;
             testCase.verifyEqual(n.t, 0.475, "RelTol", testCase.tol);
             testCase.verifyEqual(v_ref.get(), 10, "RelTol", testCase.tol);
-            testCase.verifyEqual(y.double(2), -1.1188, "RelTol", testCase.tol);
+            testCase.verifyEqual(y.double(2), -1.118845888228294, "RelTol", testCase.tol);
         end
 
         function test_netcon(testCase)
@@ -53,7 +56,7 @@ classdef test_simulation < matlab.unittest.TestCase
             example_netcon;
             set(0,'DefaultFigureVisible','on');
             testCase.verifyEqual(t_vec(750), 18.7250, "RelTol", testCase.tol);
-            testCase.verifyEqual(v_vec(750), 8.5781, "RelTol", testCase.tol);
+            testCase.verifyEqual(v_vec(750), 8.578110111980308, "RelTol", testCase.tol);
         end
 
         function test_patternstim(testCase)
@@ -72,8 +75,8 @@ classdef test_simulation < matlab.unittest.TestCase
 
         function test_temptest(testCase)
             example_temptest;
-            testCase.verifyEqual(t0, 6.1000, "RelTol", testCase.tol);
-            testCase.verifyEqual(t1, 6.0676, "RelTol", testCase.tol);
+            testCase.verifyEqual(t0, 6.1, "RelTol", testCase.tol);
+            testCase.verifyEqual(t1, 6.067608753980505, "RelTol", testCase.tol);
             testCase.verifyEqual(l0, 1);
             testCase.verifyEqual(l1, 1);
             testCase.verifyEqual(l2, 0);

--- a/+tests/test_simulation.m
+++ b/+tests/test_simulation.m
@@ -1,82 +1,82 @@
 classdef test_simulation < matlab.unittest.TestCase
 
     properties
-        tol = 1e-4;
+        tol = 1e-10;
     end
     
     methods(Test)
         
-        function test_acpot(test)
+        function test_acpot(testCase)
             set(0,'DefaultFigureVisible','off');
             example_acpot;
             set(0,'DefaultFigureVisible','on');
-            assert(abs(v2_vec(100) - 8.8916) < test.tol);
-            assert(abs(v1_vec(100) - 3.7727) < test.tol);
-            assert(abs(t_vec(100) - 2.4750) < test.tol);
+            testCase.verifyEqual(v2_vec(100), 8.8916, "RelTol", testCase.tol);
+            testCase.verifyEqual(v1_vec(100), 3.7727, "RelTol", testCase.tol);
+            testCase.verifyEqual(t_vec(100), 2.4750, "RelTol", testCase.tol);
         end
 
-        function test_alphasynapse(test)
+        function test_alphasynapse(testCase)
             example_alphasynapse;
-            assert(abs(ivec(43) - -1.9125) < test.tol);
-            assert(abs(v(101) - 28.7358) < test.tol);
+            testCase.verifyEqual(ivec(43), -1.9125, "RelTol", testCase.tol);
+            testCase.verifyEqual(v(101), 28.7358, "RelTol", testCase.tol);
         end
 
-        function test_clamps(test)
+        function test_clamps(testCase)
             example_clamps;
-            assert(abs(c2i_0 - -8.5728e-06) < test.tol);
-            assert(abs(c3i_0 - 6.0899e-06) < test.tol);
-            assert(abs(s2v_0 - -65.0000) < test.tol);
-            assert(abs(s3v_0 - -64.9987) < test.tol);
-            assert(abs(c2i_1 - -1.7144e-05) < test.tol);
-            assert(abs(c3i_1 - -65.0000) < test.tol);
-            assert(abs(s2v_1 - -65.0000) < test.tol);
-            assert(abs(s3v_1 - -64.9975) < test.tol);
+            testCase.verifyEqual(c2i_0, -8.5728e-06, "RelTol", testCase.tol);
+            testCase.verifyEqual(c3i_0, 6.0899e-06, "RelTol", testCase.tol);
+            testCase.verifyEqual(s2v_0, -65.0000, "RelTol", testCase.tol);
+            testCase.verifyEqual(s3v_0, -64.9987, "RelTol", testCase.tol);
+            testCase.verifyEqual(c2i_1, -1.7144e-05, "RelTol", testCase.tol);
+            testCase.verifyEqual(c3i_1, -65.0000, "RelTol", testCase.tol);
+            testCase.verifyEqual(s2v_1, -65.0000, "RelTol", testCase.tol);
+            testCase.verifyEqual(s3v_1, -64.9975, "RelTol", testCase.tol);
         end
 
-        function test_intfires(test)
+        function test_intfires(testCase)
             example_intfires;
-            assert(length(cell1out) == 0);
-            assert(length(cell2out) == 2);
-            assert(abs(cell2out(1) - 7.5365) < test.tol);
-            assert(abs(cell2out(2) - 16.1599) < test.tol);
+            testCase.verifyEqual(length(cell1out), 0);
+            testCase.verifyEqual(length(cell2out), 2);
+            testCase.verifyEqual(cell2out(1), 7.5365, "RelTol", testCase.tol);
+            testCase.verifyEqual(cell2out(2), 16.1599, "RelTol", testCase.tol);
         end
 
-        function test_linearmechanism(test)
+        function test_linearmechanism(testCase)
             example_linearmechanism;
-            assert(abs(n.t - 0.475) < test.tol);
-            assert(abs(v_ref.get() - 10) < test.tol);
-            assert(abs(y.double(2) - -1.1188) < test.tol);
+            testCase.verifyEqual(n.t, 0.475, "RelTol", testCase.tol);
+            testCase.verifyEqual(v_ref.get(), 10, "RelTol", testCase.tol);
+            testCase.verifyEqual(y.double(2), -1.1188, "RelTol", testCase.tol);
         end
 
-        function test_netcon(test)
+        function test_netcon(testCase)
             set(0,'DefaultFigureVisible','off');
             example_netcon;
             set(0,'DefaultFigureVisible','on');
-            assert(abs(t_vec(750) - 18.7250) < test.tol);
-            assert(abs(v_vec(750) - 8.5781) < test.tol);
+            testCase.verifyEqual(t_vec(750), 18.7250, "RelTol", testCase.tol);
+            testCase.verifyEqual(v_vec(750), 8.5781, "RelTol", testCase.tol);
         end
 
-        function test_patternstim(test)
+        function test_patternstim(testCase)
             example_patternstim;
-            assert(abs(spike_ts(4) - 4.1) < test.tol);
-            assert(spike_ids(5) == 0);
-            assert(length(spike_ts) == 12);
+            testCase.verifyEqual(spike_ts(4), 4.1, "RelTol", testCase.tol);
+            testCase.verifyEqual(spike_ids(5), 0);
+            testCase.verifyEqual(length(spike_ts), 12);
         end
 
-        function test_savestate(test)
+        function test_savestate(testCase)
             example_savestate;
-            assert(abs(t0 - 0) < test.tol);
-            assert(abs(t1 - 0.05) < test.tol);
-            assert(abs(t2 - 0) < test.tol);
+            testCase.verifyEqual(t0, 0);
+            testCase.verifyEqual(t1, 0.05, "RelTol", testCase.tol);
+            testCase.verifyEqual(t2, 0);
         end
 
-        function test_temptest(test)
+        function test_temptest(testCase)
             example_temptest;
-            assert(abs(t0 - 6.1000) < test.tol);
-            assert(abs(t1 - 6.0676) < test.tol);
-            assert(l0 == 1);
-            assert(l1 == 1);
-            assert(l2 == 0);
+            testCase.verifyEqual(t0, 6.1000, "RelTol", testCase.tol);
+            testCase.verifyEqual(t1, 6.0676, "RelTol", testCase.tol);
+            testCase.verifyEqual(l0, 1);
+            testCase.verifyEqual(l1, 1);
+            testCase.verifyEqual(l2, 0);
         end
 
     end

--- a/+utils/Paths.m
+++ b/+utils/Paths.m
@@ -1,0 +1,92 @@
+classdef Paths
+    %PATHS Single class to hold all file and directory path definitions
+    %   The same paths are needed in multiple locations in the code. Set
+    %   them here once.
+    %   The paths can be accessed through static methods, thus no instance
+    %   of the class is needed.
+    %   The returned values are character arrays.
+    %
+    %   Example:
+    %     pathvalue = utils.Paths.NeuronLibDirectory;
+
+
+    methods (Static)
+        % The function neuron_lib_directory should be the first in this
+        % list, since that is the only one where a user might need to
+        % change the value being returned.
+        
+        function value = neuron_lib_directory()
+            % The directory containing the libnrniv shared library file.
+            if ismac
+                value = '/Applications/nrn/lib';
+            elseif isunix
+                value = '/opt/nrn/lib';
+            elseif ispc
+                value = 'C:\nrn\bin';
+            else
+                error('Unknown operating system');
+            end
+            % Make sure only native filesep are used.
+            value = fullfile(value);
+        end
+
+        function value = libnrniv_file()
+            % Full path of the libnrniv shared library file.
+            lib_dir = utils.Paths.neuron_lib_directory();
+            if ismac
+                value = fullfile(lib_dir, 'libnrniv.dylib');
+            elseif isunix
+                value = fullfile(lib_dir, 'libnrniv.so');
+            elseif ispc
+                value = fullfile(lib_dir, 'libnrniv.dll');
+            else
+                error('Unknown operating system');
+            end
+        end
+
+        function value = toolbox_directory()
+            % Full path of the top level directory of this toolbox
+            value = fileparts(fileparts(mfilename("fullpath")));
+        end
+
+        function value = toolbox_lib_directory()
+            value = fullfile(utils.Paths.toolbox_directory(), 'neuron');
+
+        end
+
+        function value = examples_directory()
+            value = fullfile(utils.Paths.toolbox_directory(), 'examples');
+
+        end
+
+        function value = matlab_lib_directory()
+            % The directory containing the matlab shared library files.
+            if ismac
+                value = fullfile(matlabroot, "bin", "maci64");
+            elseif isunix
+                value = fullfile(matlabroot, "bin", "glnxa64");
+            elseif ispc
+                value = fullfile(matlabroot, "extern", "lib", "win64", "mingw64");
+            else
+                error('Unknown operating system');
+            end
+            % Make sure only native filesep are used.
+            value = fullfile(value);
+        end
+
+        function value = libmex_file()
+            % Full path of the libmex shared library file.
+            lib_dir = utils.Paths.matlab_lib_directory();
+            if ismac
+                value = fullfile(lib_dir, 'libmex.dylib');
+            elseif isunix
+                value = fullfile(lib_dir, 'libmex.so');
+            elseif ispc
+                value = fullfile(lib_dir, 'libmex.lib');
+            else
+                error('Unknown operating system');
+            end
+        end
+    end
+end
+

--- a/+utils/build_interface.m
+++ b/+utils/build_interface.m
@@ -12,16 +12,21 @@ function build_interface()
         error("No C++ compiler found.");
     elseif ispc && ~check_compiler('C++', 'mingw64-g++')
         error("On windows the C++ compiler must be mingw64")
+    % elseif ismac || isunix
+    %     error("Do we need a condition for mac or linux? What should they be?")
     end
 
     % Create definition file for NEURON library.
     HeaderFilePath = "source/nrnmatlab.h";
     SourceFilePath = "source/nrnmatlab.cpp";
-    if ispc
+    if ismac
+        StaticLibPath = string(getenv('CONDA_PREFIX')) + "/lib/python3.11/site-packages/neuron/.data/lib/libnrniv.dylib"; % Check?
+        LibMexPath = fullfile(matlabroot, "bin", "maci64", "libmex.dylib"); % For mexPrintf
+    elseif ispc
         StaticLibPath = "source/libnrniv.a";
         LibMexPath = fullfile(matlabroot, "extern", "lib", "win64", "mingw64", "libmex.lib"); % For mexPrintf
     elseif isunix
-        StaticLibPath = "/home/kian.ohara/.conda/envs/neuron9/lib/python3.11/site-packages/neuron/.data/lib/libnrniv.so";
+        StaticLibPath = string(getenv('CONDA_PREFIX')) + "/lib/python3.11/site-packages/neuron/.data/lib/libnrniv.so";
         LibMexPath = fullfile(matlabroot, "bin", "glnxa64", "libmex.so"); % For mexPrintf
     end
     HeadersIncludePath = "source";
@@ -34,7 +39,8 @@ function build_interface()
             PackageName="neuron", ...
             TreatObjectPointerAsScalar=true, ...
             TreatConstCharPointerAsCString=true, ...
-            AdditionalCompilerFlags="-g");
+            AdditionalCompilerFlags="-g", ...
+            Verbose=true);
     catch ME
         disp(ME);
         error("Error while running clibgen.generateLibraryDefinition(), please check if you have administrator rights.")

--- a/+utils/build_interface.m
+++ b/+utils/build_interface.m
@@ -17,8 +17,13 @@ function build_interface()
     % Create definition file for NEURON library.
     HeaderFilePath = "source/nrnmatlab.h";
     SourceFilePath = "source/nrnmatlab.cpp";
-    StaticLibPath = "source/libnrniv.a";
-    LibMexPath = fullfile(matlabroot, "extern", "lib", "win64", "mingw64", "libmex.lib"); % For mexPrintf
+    if ispc
+        StaticLibPath = "source/libnrniv.a";
+        LibMexPath = fullfile(matlabroot, "extern", "lib", "win64", "mingw64", "libmex.lib"); % For mexPrintf
+    elseif isunix
+        StaticLibPath = "/home/kian.ohara/.conda/envs/neuron9/lib/python3.11/site-packages/neuron/.data/lib/libnrniv.so";
+        LibMexPath = fullfile(matlabroot, "bin", "glnxa64", "libmex.so"); % For mexPrintf
+    end
     HeadersIncludePath = "source";
     try
         clibgen.generateLibraryDefinition(HeaderFilePath, ...
@@ -28,7 +33,8 @@ function build_interface()
             IncludePath=HeadersIncludePath, ...
             PackageName="neuron", ...
             TreatObjectPointerAsScalar=true, ...
-            TreatConstCharPointerAsCString=true);
+            TreatConstCharPointerAsCString=true, ...
+            AdditionalCompilerFlags="-g");
     catch ME
         disp(ME);
         error("Error while running clibgen.generateLibraryDefinition(), please check if you have administrator rights.")

--- a/+utils/build_interface.m
+++ b/+utils/build_interface.m
@@ -20,20 +20,20 @@ function build_interface()
     HeaderFilePath = "source/nrnmatlab.h";
     SourceFilePath = "source/nrnmatlab.cpp";
     if ismac
-        StaticLibPath = string(getenv('CONDA_PREFIX')) + "/lib/python3.11/site-packages/neuron/.data/lib/libnrniv.dylib"; % Check?
+        NrnLibPath = "<path-to-neuron-libaries>/libnrniv.dylib";
         LibMexPath = fullfile(matlabroot, "bin", "maci64", "libmex.dylib"); % For mexPrintf
     elseif ispc
-        StaticLibPath = "source/libnrniv.a";
+        NrnLibPath = "source/libnrniv.a";
         LibMexPath = fullfile(matlabroot, "extern", "lib", "win64", "mingw64", "libmex.lib"); % For mexPrintf
     elseif isunix
-        StaticLibPath = string(getenv('CONDA_PREFIX')) + "/lib/python3.11/site-packages/neuron/.data/lib/libnrniv.so";
+        NrnLibPath = "<path-to-neuron-libaries>/libnrniv.so";
         LibMexPath = fullfile(matlabroot, "bin", "glnxa64", "libmex.so"); % For mexPrintf
     end
     HeadersIncludePath = "source";
     try
         clibgen.generateLibraryDefinition(HeaderFilePath, ...
             SupportingSourceFiles=SourceFilePath, ...
-            Libraries=[StaticLibPath, LibMexPath], ...
+            Libraries=[NrnLibPath, LibMexPath], ...
             OverwriteExistingDefinitionFiles=true, ...
             IncludePath=HeadersIncludePath, ...
             PackageName="neuron", ...
@@ -42,8 +42,11 @@ function build_interface()
             AdditionalCompilerFlags="-g", ...
             Verbose=true);
     catch ME
-        disp(ME);
-        error("Error while running clibgen.generateLibraryDefinition(), please check if you have administrator rights.")
+        if ispc
+            error("Error while running clibgen.generateLibraryDefinition(), please check if you have administrator rights.")
+        else
+            rethrow(ME);
+        end
     end
 
     % We want to use the generated .m file, not the .mlx file, because we

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NEURON Toolbox for MATLAB
 
-> :warning:
-* only Windows with MinGW is supported.
-* only Linux with GCC & Matlab 2023a
-* [Under Development: only Mac with Intel CPU is supported.]
+> :warning: This toolbox has specific requirements depending on operating system
+> * Windows: Matlab R2022a or higher, MinGW compiler, and Administrator rights
+> * Linux: Matlab R2023a or higher and GCC compiler
+> * Mac: [Under Development] Matlab R2023a or higher, Intel Macs only and Clang compiler
 
 The NEURON Toolbox provides a MATLAB API to NEURON, using the MATLAB
 provided clibgen and clib packages to connect MATLAB and NEURON.
@@ -42,30 +42,12 @@ For more detailed technical information about e.g. code structure, see [doc/DEV_
 ## Usage
 
 ### Setup
-#### One time setup Actions
-0. make sure NEURON is installed (see http://neuron.yale.edu/).
-1. make sure to setup your MEX C++ compiler; for more information about this, run `mex -setup cpp` in MATLAB.
 
-   [ **Windows** Ensure MinGW-w64 is set as your MEX C++ compiler.]
+Before using the toolbox for the first time, go through the [first time only](#first-time) steps. On Windows, these steps need to be run from a Matlab session with Administrator rights.
 
-To get the toolbox working on your machine:
+Linux and Mac: To be able to use the toolbox, Matlab always needs to be started from an environment with specific environment variables, see [first time only](#first-time) for details. Also, output printed from within NEURON itself will show in the shell from which Matlab is started, instead of the Matlab command window.
 
-**bash** Add the Neuron libraries to your run-time path before running Matlab.
-  - **Linux** Set your LD_LIBRARY_PATH
-  - **MacOS** Set your DYLD_LIBRARY_PATH
-  - **Windows** (Automatically set within matlab)
-
-run the MATLAB scripts in the following order:
-- **setup**
-    - add the appropriate directories to your path (you might need to change the hardcoded NEURON installation directory)
-    - **this script needs to be run every time a new MATLAB session is started**
-- **utils.build_interface**
-    - to add the appropriate directories to your path (you might need to change the hardcoded NEURON Library directory)
-    - to build the library interface (neuron/neuronInterface.dll)
-    - **this script needs to be run only once to generate the library interface**,
-      it only needs to be re-run if the interface changes (for example when using a newer Neuron version)
-    - please note: you need administrator rights (always? or just windows?) to run build_interface
-      (i.e. you need to run MATLAB as administrator (always? or just windows?))
+In each Matlab session where you want to use the toolbox, run the script **setup.m**. Alternatively, add a call to this setup.m [in your startup.m file](https://www.mathworks.com/help/matlab/ref/startup.html).
 
 ### Example scripts
 
@@ -139,3 +121,28 @@ A non-exhaustive list:
   use `t = n.Vector().record(ref);`; instead we have to write
   `t = n.Vector(); t.record(ref);`. This is due to the way dynamic function
   calls are setup with `subsref`.
+
+<a id="first-time"></a>
+## First time only
+
+Here the steps are given that need to be done only once to be able to use the toolbox.
+
+1. Make sure NEURON is installed (see http://neuron.yale.edu/).
+2. Linux and Mac: start Matlab from a bash shell with the correct PATH, HOC_LIBRARY_PATH and on Linux LD_LIBRARY_PATH, on Mac DYLD_LIBRARY_PATH. Matlab always needs to be started from such a shell, not just the first time only.
+   - Get the directory where libnrniv is installed, within the NEURON installation folder
+   - Get the directory where this toolbox is installed
+   - Determine the value of matlabroot (https://nl.mathworks.com/help/matlab/ref/matlabroot.html)
+   - Use these values to set the PATH, HOC_LIBRARY_PATH and LD_LIBRARY_PATH / DYLD_LIBRARY_PATH starting Matlab. Example shell scripts are available for [Linux](doc/example_startup_scripts/linux_matlab.sh) and [Mac](doc/example_startup_scripts/linux_matlab.sh). Within these scripts, replace `<..matlabroot..>`, `<..neuron-directory..>` and `<..matlabneuroninterface..>` with the correct directory paths.
+3. Make sure to setup your MEX C++ compiler; for more information about this, run `mex -setup cpp` in MATLAB.
+   - Windows: MinGW-w64
+   - Linux: gcc
+   - Mac: clang
+4. Update neuron_lib_directory in +utils/Paths.m if needed.
+5. Run the MATLAB scripts in the following order:
+   - **setup**
+      - This script needs to be run every time a new MATLAB session is started
+      - It adds the appropriate directories to your path 
+   - **utils.build_interface**
+      - This script needs to be run once to generate the library interface, and only needs to be re-run if the interface changes (for example when using a newer Neuron version)
+      - It builds the library interface (neuron/neuronInterface.*)
+      - Please note: on Windows you need administrator rights to run build_interface

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Here the steps are given that need to be done only once to be able to use the to
    - Get the directory where libnrniv is installed, within the NEURON installation folder
    - Get the directory where this toolbox is installed
    - Determine the value of matlabroot (https://nl.mathworks.com/help/matlab/ref/matlabroot.html)
-   - Use these values to set the PATH, HOC_LIBRARY_PATH and LD_LIBRARY_PATH / DYLD_LIBRARY_PATH starting Matlab. Example shell scripts are available for [Linux](doc/example_startup_scripts/linux_matlab.sh) and [Mac](doc/example_startup_scripts/linux_matlab.sh). Within these scripts, replace `<..matlabroot..>`, `<..neuron-directory..>` and `<..matlabneuroninterface..>` with the correct directory paths.
+   - Use these values to set the HOC_LIBRARY_PATH and LD_LIBRARY_PATH / DYLD_LIBRARY_PATH. Example shell scripts are available for [Linux](doc/example_startup_scripts/linux_matlab.sh) and [Mac](doc/example_startup_scripts/linux_matlab.sh). Within these scripts, replace `<..matlabroot..>`, `<..neuron-directory..>` and `<..matlabneuroninterface..>` with the correct directory paths.
+   - Depending on how Neuron was installed, it may be that also the PATH variable needs to be updated. See item 6 'Check it works'.
 3. Make sure to setup your MEX C++ compiler; for more information about this, run `mex -setup cpp` in MATLAB.
    - Windows: MinGW-w64
    - Linux: gcc
@@ -146,3 +147,8 @@ Here the steps are given that need to be done only once to be able to use the to
       - This script needs to be run once to generate the library interface, and only needs to be re-run if the interface changes (for example when using a newer Neuron version)
       - It builds the library interface (neuron/neuronInterface.*)
       - Please note: on Windows you need administrator rights to run build_interface
+6. Check it works:
+   - With the previous steps completed, run the matlab scripts **example_run** and **example_acpot** to check that the matlabneuroninterface works.
+   - Linux and Mac, additionally: 
+      - Run **example_loadfile** to check that the HOC_LIBRARY_PATH has been set correctly.
+      - Run **example_mod** to check that the PATH is correct. If this example fails, update the PATH per the instructions in the example startup script.

--- a/README.md
+++ b/README.md
@@ -1,74 +1,86 @@
 # NEURON Toolbox for MATLAB
 
-> :warning: For now, only Windows with MinGW is supported.
+> :warning:
+* only Windows with MinGW is supported.
+* only Linux with GCC & Matlab 2023a
+* [Under Development: only Mac with Intel CPU is supported.]
 
-The NEURON Toolbox provides a MATLAB API to NEURON, using the MATLAB 
+The NEURON Toolbox provides a MATLAB API to NEURON, using the MATLAB
 provided clibgen and clib packages to connect MATLAB and NEURON.
 
-The [NEURON simulation environment](https://www.neuron.yale.edu/) is used 
-in laboratories and classrooms around the world for building and using 
+The [NEURON simulation environment](https://www.neuron.yale.edu/) is used
+in laboratories and classrooms around the world for building and using
 computational models of neurons and networks of neurons.
 
 About this toolbox:
 
-- The +neuron package defines the MATLAB API to NEURON. All calls to 
-  NEURON from MATLAB should only use methods and properties exposed by 
-  the classes in this package and should not directly use clib.neuron. 
-  This is because the +neuron package takes care of proper initialization 
+- The +neuron package defines the MATLAB API to NEURON. All calls to
+  NEURON from MATLAB should only use methods and properties exposed by
+  the classes in this package and should not directly use clib.neuron.
+  This is because the +neuron package takes care of proper initialization
   of NEURON, and correct cleanup of NEURON objects.
-- With clib, the NEURON shared library can be used through the clibgen 
-  generated wrapper interface. The functions and variables exposed in the 
-  wrapper interface can be used directly from MATLAB, e.g. it is possible 
-  to call the NEURON function nrn_sec_pop from MATLAB with 
+- With clib, the NEURON shared library can be used through the clibgen
+  generated wrapper interface. The functions and variables exposed in the
+  wrapper interface can be used directly from MATLAB, e.g. it is possible
+  to call the NEURON function nrn_sec_pop from MATLAB with
   `clib.neuron.nrn_sec_pop()`.
-- With clibgen a MATLAB interface to the NEURON library is built. This 
-  results in a wrapper shared library. Prebuilt wrappers for certain 
+- With clibgen a MATLAB interface to the NEURON library is built. This
+  results in a wrapper shared library. Prebuilt wrappers for certain
   Operating System and Compiler combinations may be provided.
-    - To generate the interface, the underlying library should preferably 
-      expose an API in a header file. Since NEURON itself does not provide 
-      a C or C++ API that is directly useable in clibgen, the MATLAB-NEURON 
-      project also contains header and C++ files that define a C++ API, 
-      containing the NEURON functionality that needs to be available from 
+    - To generate the interface, the underlying library should preferably
+      expose an API in a header file. Since NEURON itself does not provide
+      a C or C++ API that is directly useable in clibgen, the MATLAB-NEURON
+      project also contains header and C++ files that define a C++ API,
+      containing the NEURON functionality that needs to be available from
       MATLAB.
 
 
-MATLAB is a registered trademark of The MathWorks, Inc. 
+MATLAB is a registered trademark of The MathWorks, Inc.
 
 For more detailed technical information about e.g. code structure, see [doc/DEV_README.md](doc/DEV_README.md).
 
 ## Usage
 
 ### Setup
+#### One time setup Actions
+0. make sure NEURON is installed (see http://neuron.yale.edu/).
+1. make sure to setup your MEX C++ compiler; for more information about this, run `mex -setup cpp` in MATLAB.
 
-First, make sure **NEURON 9** for Windows is installed (see http://neuron.yale.edu/).
-Also make sure to set MinGW-w64 as your MEX C++ compiler; for more information about this, run `mex -setup cpp` in MATLAB.
+   [ **Windows** Ensure MinGW-w64 is set as your MEX C++ compiler.]
 
-To get the toolbox working on your machine, run the MATLAB scripts in the following order:
-- **setup** 
-    - to add the appropriate directories to your path (you might need to
-      change the hardcoded NEURON installation directory)
+To get the toolbox working on your machine:
+
+**bash** Add the Neuron libraries to your run-time path before running Matlab.
+  - **Linux** Set your LD_LIBRARY_PATH
+  - **MacOS** Set your DYLD_LIBRARY_PATH
+  - **Windows** (Automatically set within matlab)
+
+run the MATLAB scripts in the following order:
+- **setup**
+    - add the appropriate directories to your path (you might need to change the hardcoded NEURON installation directory)
     - **this script needs to be run every time a new MATLAB session is started**
 - **utils.build_interface**
+    - to add the appropriate directories to your path (you might need to change the hardcoded NEURON Library directory)
     - to build the library interface (neuron/neuronInterface.dll)
     - **this script needs to be run only once to generate the library interface**,
       it only needs to be re-run if the interface changes (for example when using a newer Neuron version)
-    - please note: you need administrator rights to run build_interface
-      (i.e. you need to run MATLAB as administrator)
+    - please note: you need administrator rights (always? or just windows?) to run build_interface
+      (i.e. you need to run MATLAB as administrator (always? or just windows?))
 
 ### Example scripts
 
 A comprehensive example live script, encompassing the smaller examples and providing additional explanation, can be found at **examples/example_livescript.mlx**.
 
 Smaller example scripts are available at:
-- **examples/example_run.m** 
+- **examples/example_run.m**
     - to initialize a Neuron session and call some top-level functions from the library
-- **examples/example_vector.m** 
+- **examples/example_vector.m**
     - to create a Vector object and calculate some properties
-- **examples/example_morph.m** 
+- **examples/example_morph.m**
     - to generate a morphology by connecting different Sections, and add 3D points to them
-- **examples/example_crash.m** 
+- **examples/example_crash.m**
     - to cause a :warning: crash by causing a method with the wrong arguments
-- **examples/example_acpot.m** 
+- **examples/example_acpot.m**
     - to generate an action potential
 
 **example_acpot** should result in:
@@ -85,7 +97,7 @@ n = neuron.Neuron();
 ```
 
 Now all top-level variables, functions and classes can be accessed
-using this object. The available variables, functions and classes, as 
+using this object. The available variables, functions and classes, as
 well as their Neuron types can be displayed with:
 
 ```matlab
@@ -100,7 +112,7 @@ n.fadvance();               % Advance by one timestep
 v = n.Vector();             % Create a Vector object
 ```
 
-If you create an object like a Vector, you can see a list of its 
+If you create an object like a Vector, you can see a list of its
 properties and methods with:
 
 ```matlab

--- a/doc/example_startup_scripts/linux_matlab.sh
+++ b/doc/example_startup_scripts/linux_matlab.sh
@@ -13,21 +13,27 @@ NRNML_INTERFACEPATH="<..matlabneuroninterface..>/neuron/"
 NRNML_NRNPATH="<..neuron-directory..>/"
 
 # Exact location of the following subdirectories might depend on how NEURON was installed, do check!
-# Directory containing nrnivmodl executable
-NRNML_BINNRNPATH="${NRNML_NRNPATH}bin/"
 # Directory containing libnrniv, libnrnpython3, libcorenrnmech_internal shared libraries
 NRNML_LIBNRNPATH="${NRNML_NRNPATH}lib/"
 # Directory containing stdlib.hoc, stdrun.hoc and many more .hoc files
 NRNML_HOCNRNPATH="${NRNML_NRNPATH}share/nrn/lib/hoc/"
 
-# Update to PATH needed, to be able to find nrnivmodl executable for compiling mod files
-export PATH="${PATH}:${NRNML_BINNRNPATH}:"
-echo ${PATH}
 # Update to LD_LIBRARY_PATH needed, to find dependencies of the interface library
 export LD_LIBRARY_PATH="${NRNML_LIBMEXPATH}:${NRNML_LIBNRNPATH}:${NRNML_INTERFACEPATH}:${LD_LIBRARY_PATH}"
 echo ${LD_LIBRARY_PATH}
 # Update to HOC_LIBRARY_PATH needed, to be able to find the .hoc files distributed with NEURON
 export HOC_LIBRARY_PATH="${NRNML_HOCNRNPATH}:${HOC_LIBRARY_PATH}"
 echo ${HOC_LIBRARY_PATH}
+
+# Update to PATH needed, to be able to find nrnivmodl for compiling mod files?
+# It should usually NOT be needed to update the PATH variable, but it does depend on how NEURON is installed.
+# If it is needed to update the path, it would be to be able to find the correct nrnivmodl.
+# An example for a conda environment named neuron9:
+# - The correct nrnivmodl will be in envs/neuron9/bin
+# - The underlying nrnivmodl, that should NOT be put on the path, is in envs/neuron9/lib/python3.11/site-packages/neuron/.data/bin
+# Thus, a correct path could be
+#NRNML_BINNRNPATH="${HOME}/.conda/envs/neuron9/bin/"
+#export PATH="${PATH}:${NRNML_BINNRNPATH}:"
+echo ${PATH}
 
 matlab

--- a/doc/example_startup_scripts/linux_matlab.sh
+++ b/doc/example_startup_scripts/linux_matlab.sh
@@ -1,6 +1,33 @@
 #!/bin/bash
 
-export LD_LIBRARY_PATH='matlabneuroninterface/neuron/:<neuron-directory>/lib/':$LD_LIBRARY_PATH
-echo $LD_LIBRARY_PATH
+# ONLY the first three variables should need to be set. However, depending on
+# how NEURON was installed, also the relative parts of the second set of three variables
+# might need to be adapted.
+# Do include the final slash as part of these paths
+
+# The directory where libmex is installed
+NRNML_LIBMEXPATH="<..matlabroot..>/bin/glnxa64/"
+# The 'neuron' directory within the directory where this toolbox is installed
+NRNML_INTERFACEPATH="<..matlabneuroninterface..>/neuron/"
+# The directory where NEURON is installed, see also the next three variables
+NRNML_NRNPATH="<..neuron-directory..>/"
+
+# Exact location of the following subdirectories might depend on how NEURON was installed, do check!
+# Directory containing nrnivmodl executable
+NRNML_BINNRNPATH="${NRNML_NRNPATH}bin/"
+# Directory containing libnrniv, libnrnpython3, libcorenrnmech_internal shared libraries
+NRNML_LIBNRNPATH="${NRNML_NRNPATH}lib/"
+# Directory containing stdlib.hoc, stdrun.hoc and many more .hoc files
+NRNML_HOCNRNPATH="${NRNML_NRNPATH}share/nrn/lib/hoc/"
+
+# Update to PATH needed, to be able to find nrnivmodl executable for compiling mod files
+export PATH="${PATH}:${NRNML_BINNRNPATH}:"
+echo ${PATH}
+# Update to LD_LIBRARY_PATH needed, to find dependencies of the interface library
+export LD_LIBRARY_PATH="${NRNML_LIBMEXPATH}:${NRNML_LIBNRNPATH}:${NRNML_INTERFACEPATH}:${LD_LIBRARY_PATH}"
+echo ${LD_LIBRARY_PATH}
+# Update to HOC_LIBRARY_PATH needed, to be able to find the .hoc files distributed with NEURON
+export HOC_LIBRARY_PATH="${NRNML_HOCNRNPATH}:${HOC_LIBRARY_PATH}"
+echo ${HOC_LIBRARY_PATH}
 
 matlab

--- a/doc/example_startup_scripts/linux_matlab.sh
+++ b/doc/example_startup_scripts/linux_matlab.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH='matlabneuroninterface/neuron/:<neuron-directory>/lib/':$LD_LIBRARY_PATH
+echo $LD_LIBRARY_PATH
+
+matlab

--- a/doc/example_startup_scripts/mac_matlab.sh
+++ b/doc/example_startup_scripts/mac_matlab.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export DYLD_LIBRARY_PATH='/Applications/MATLAB_R2023a.app/bin/maci64: \
+                        /Applications/MATLAB_R2023a.app/sys/os/maci64: \
+                        <... matlabneuroninterface ...>/neuron/: \
+                        <... neuron-directory ...>/lib/:'$DYLD_LIBRARY_PATH
+echo $DYLD_LIBRARY_PATH
+
+matlab

--- a/doc/example_startup_scripts/mac_matlab.sh
+++ b/doc/example_startup_scripts/mac_matlab.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
-
 # ONLY the first three variables should need to be set. However, depending on
-# how NEURON was installed, also the relative parts of the second set of three variables
-# might need to be adapted.
-# Do include the final slash as part of these paths
-
-# The directory where libmex is installed
-NRNML_LIBMEXPATH="<..matlabroot..>/bin/maci64/"
-# The 'neuron' directory within the directory where this toolbox is installed
+#   how NEURON or MATLAB was installed, also the relative parts of the second set of variables
+#   might need to be adapted.
+# DO include the final slash as part of these paths!
+# 1. The main directory where MATLAB is installed, probably /Applications/MATLAB_R2023a.app/
+NRNML_MLROOT = "<..matlabroot..>/"
+# 2. The 'neuron' directory within the directory where this toolbox is installed
 NRNML_INTERFACEPATH="<..matlabneuroninterface..>/neuron/"
-# The directory where NEURON is installed, see also the next three variables
+# 3. The directory where NEURON is installed, see also the next three variables
 NRNML_NRNPATH="<..neuron-directory..>/"
 
+# Exact location of the following subdirectories might depend on how MATLAB was installed
+# The directory within the MATLAB installation where libmex is installed
+NRNML_MLLIBMEXPATH="${NRNML_MLROOT}bin/maci64/"
+# The directory within the MATLAB installation where other dylibs are installed
+NRNML_MLLIBSPATH="${NRNML_MLROOT}sys/os/maci64/"
+# The directory within the MATLAB installation where the MATLAB executable is installed
+NRNML_MLEXEPATH="${NRNML_MLROOT}Contents/MacOS/"
 # Exact location of the following subdirectories might depend on how NEURON was installed, do check!
 # Directory containing nrnivmodl executable
 NRNML_BINNRNPATH="${NRNML_NRNPATH}bin/"
@@ -25,10 +30,14 @@ NRNML_HOCNRNPATH="${NRNML_NRNPATH}share/nrn/lib/hoc/"
 export PATH="${PATH}:${NRNML_BINNRNPATH}:"
 echo ${PATH}
 # Update to DYLD_LIBRARY_PATH needed, to find dependencies of the interface library
-export DYLD_LIBRARY_PATH="${NRNML_LIBMEXPATH}:${NRNML_LIBNRNPATH}:${NRNML_INTERFACEPATH}:${DYLD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="${NRNML_MLLIBMEXPATH}:${NRNML_MLLIBSPATH}:${NRNML_LIBNRNPATH}:${NRNML_INTERFACEPATH}:${DYLD_LIBRARY_PATH}"
 echo ${DYLD_LIBRARY_PATH}
 # Update to HOC_LIBRARY_PATH needed, to be able to find the .hoc files distributed with NEURON
 export HOC_LIBRARY_PATH="${NRNML_HOCNRNPATH}:${HOC_LIBRARY_PATH}"
 echo ${HOC_LIBRARY_PATH}
 
-matlab
+# Start matlab AND also set DYLD_LIBRARY_PATH on the same line!
+#   Because as of MacOS 10.11, the "DYLD_LIBRARY_PATH" environment variable is stripped from the
+#   environment when launching protected executables. To work around this, prepend the setting of
+#   the variable right at the beginning of the command you run.
+DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" ${NRNML_MLEXEPATH}MATLAB

--- a/doc/example_startup_scripts/mac_matlab.sh
+++ b/doc/example_startup_scripts/mac_matlab.sh
@@ -1,9 +1,34 @@
 #!/bin/bash
 
-export DYLD_LIBRARY_PATH='/Applications/MATLAB_R2023a.app/bin/maci64: \
-                        /Applications/MATLAB_R2023a.app/sys/os/maci64: \
-                        <... matlabneuroninterface ...>/neuron/: \
-                        <... neuron-directory ...>/lib/:'$DYLD_LIBRARY_PATH
-echo $DYLD_LIBRARY_PATH
+
+# ONLY the first three variables should need to be set. However, depending on
+# how NEURON was installed, also the relative parts of the second set of three variables
+# might need to be adapted.
+# Do include the final slash as part of these paths
+
+# The directory where libmex is installed
+NRNML_LIBMEXPATH="<..matlabroot..>/bin/maci64/"
+# The 'neuron' directory within the directory where this toolbox is installed
+NRNML_INTERFACEPATH="<..matlabneuroninterface..>/neuron/"
+# The directory where NEURON is installed, see also the next three variables
+NRNML_NRNPATH="<..neuron-directory..>/"
+
+# Exact location of the following subdirectories might depend on how NEURON was installed, do check!
+# Directory containing nrnivmodl executable
+NRNML_BINNRNPATH="${NRNML_NRNPATH}bin/"
+# Directory containing libnrniv, libnrnpython3, libcorenrnmech_internal shared libraries
+NRNML_LIBNRNPATH="${NRNML_NRNPATH}lib/"
+# Directory containing stdlib.hoc, stdrun.hoc and many more .hoc files
+NRNML_HOCNRNPATH="${NRNML_NRNPATH}share/nrn/lib/hoc/"
+
+# Update to PATH needed, to be able to find nrnivmodl executable for compiling mod files
+export PATH="${PATH}:${NRNML_BINNRNPATH}:"
+echo ${PATH}
+# Update to DYLD_LIBRARY_PATH needed, to find dependencies of the interface library
+export DYLD_LIBRARY_PATH="${NRNML_LIBMEXPATH}:${NRNML_LIBNRNPATH}:${NRNML_INTERFACEPATH}:${DYLD_LIBRARY_PATH}"
+echo ${DYLD_LIBRARY_PATH}
+# Update to HOC_LIBRARY_PATH needed, to be able to find the .hoc files distributed with NEURON
+export HOC_LIBRARY_PATH="${NRNML_HOCNRNPATH}:${HOC_LIBRARY_PATH}"
+echo ${HOC_LIBRARY_PATH}
 
 matlab

--- a/examples/basic_functionality/example_run.m
+++ b/examples/basic_functionality/example_run.m
@@ -2,7 +2,7 @@
 % Initialize a neuron session and call some functions.
 
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/basic_functionality/example_vector.m
+++ b/examples/basic_functionality/example_vector.m
@@ -2,7 +2,7 @@
 % Initialize a neuron session, record time and call some vector methods.
 
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 n.hoc_oc("create soma");

--- a/examples/input/example_loadfile.m
+++ b/examples/input/example_loadfile.m
@@ -1,5 +1,5 @@
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 soma = n.Section("soma");

--- a/examples/input/example_mod.m
+++ b/examples/input/example_mod.m
@@ -1,5 +1,5 @@
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/input/example_mod.m
+++ b/examples/input/example_mod.m
@@ -12,20 +12,33 @@ n.reset_sections();
 examples_path = fileparts(mfilename('fullpath'));
 mod_path = fullfile(examples_path, 'mod');
 system("nrnivmodl " + mod_path);
-output_path = fullfile(pwd, 'nrnmech.dll');
-dll_path = fullfile(mod_path, 'nrnmech.dll');
+
+if ispc    
+    libfile = 'nrnmech.dll';
+    output_path = fullfile(pwd, libfile);
+elseif ismac
+    % What is the filename, and where is it created, on mac?
+    libfile = 'libnrnmech.so';
+    output_path = fullfile(pwd, 'x86_64', libfile);
+    error('Not implemented yet, please update this file with correct file and directory name')
+else
+    libfile = 'libnrnmech.so';
+    output_path = fullfile(pwd, 'x86_64', libfile);
+end
+dll_path = fullfile(mod_path, libfile);
 try
     movefile(output_path, dll_path, 'f');
 catch
-    warning("Could not move DLL; does the file already exist?");
+    warning("Could not move shared library file; does the file already exist?");
     delete(output_path);
 end
 
 % Import dll into neuron.
 try
+    % Also for linux and mac use nrn_load_dll
     n.nrn_load_dll(strrep(dll_path, "\", "/"));
 catch
-    warning("Could not load DLL; is it already loaded?");
+    warning("Could not load shared library file; is it already loaded?");
 end
 
 % Try to find 'hd' mechanism; now it should exist.

--- a/examples/morphology/example_allsec.m
+++ b/examples/morphology/example_allsec.m
@@ -1,5 +1,5 @@
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/morphology/example_morph.m
+++ b/examples/morphology/example_morph.m
@@ -2,7 +2,7 @@
 % Creating and editing a morphology.
 
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/plotting/example_plotshape.m
+++ b/examples/plotting/example_plotshape.m
@@ -1,5 +1,5 @@
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/plotting/example_rangevarplot.m
+++ b/examples/plotting/example_rangevarplot.m
@@ -1,5 +1,5 @@
 % Init neuron.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/simulation/example_acpot.m
+++ b/examples/simulation/example_acpot.m
@@ -2,7 +2,7 @@
 % Generates a plot of an action potential.
 
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/simulation/example_acpot.m
+++ b/examples/simulation/example_acpot.m
@@ -50,16 +50,16 @@ icllist = n.List("IClamp");
 disp("Number of Vectors: " + veclist.count());
 disp("Number of IClamps: " + icllist.count());
 
-% % Plot results.
-% fig = figure;
-% ax = axes(fig);
-% hold on;
-% % Providing a Vector as an input to plot() calls Vector.double() 
-% % in the background.
-% plot(ax, t_vec, v1_vec, "DisplayName", "Center of axon");
-% plot(ax, t_vec, v2_vec, "DisplayName", "End of branch");
-% hold off;
-% legend(ax);
-% title(ax, "Action potential");
-% xlabel(ax, "t (ms)");
-% ylabel(ax, "voltage (mV)");
+% Plot results.
+fig = figure;
+ax = axes(fig);
+hold on;
+% Providing a Vector as an input to plot() calls Vector.double()
+% in the background.
+plot(ax, t_vec, v1_vec, "DisplayName", "Center of axon");
+plot(ax, t_vec, v2_vec, "DisplayName", "End of branch");
+hold off;
+legend(ax);
+title(ax, "Action potential");
+xlabel(ax, "t (ms)");
+ylabel(ax, "voltage (mV)");

--- a/examples/simulation/example_acpot.m
+++ b/examples/simulation/example_acpot.m
@@ -50,16 +50,16 @@ icllist = n.List("IClamp");
 disp("Number of Vectors: " + veclist.count());
 disp("Number of IClamps: " + icllist.count());
 
-% Plot results.
-fig = figure;
-ax = axes(fig);
-hold on;
-% Providing a Vector as an input to plot() calls Vector.double() 
-% in the background.
-plot(ax, t_vec, v1_vec, "DisplayName", "Center of axon");
-plot(ax, t_vec, v2_vec, "DisplayName", "End of branch");
-hold off;
-legend(ax);
-title(ax, "Action potential");
-xlabel(ax, "t (ms)");
-ylabel(ax, "voltage (mV)");
+% % Plot results.
+% fig = figure;
+% ax = axes(fig);
+% hold on;
+% % Providing a Vector as an input to plot() calls Vector.double() 
+% % in the background.
+% plot(ax, t_vec, v1_vec, "DisplayName", "Center of axon");
+% plot(ax, t_vec, v2_vec, "DisplayName", "End of branch");
+% hold off;
+% legend(ax);
+% title(ax, "Action potential");
+% xlabel(ax, "t (ms)");
+% ylabel(ax, "voltage (mV)");

--- a/examples/simulation/example_alphasynapse.m
+++ b/examples/simulation/example_alphasynapse.m
@@ -1,5 +1,5 @@
 % Minimal AlphaSynapse example.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/simulation/example_clamps.m
+++ b/examples/simulation/example_clamps.m
@@ -5,7 +5,7 @@
 % how much extra current they need to stabilize and how close the
 % voltage gets
 
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/simulation/example_intfires.m
+++ b/examples/simulation/example_intfires.m
@@ -1,5 +1,5 @@
 % Minimal Intfire2/IntFire4/NetStim/NetCon example.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 soma = n.Section("soma");

--- a/examples/simulation/example_linearmechanism.m
+++ b/examples/simulation/example_linearmechanism.m
@@ -1,5 +1,5 @@
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/simulation/example_netcon.m
+++ b/examples/simulation/example_netcon.m
@@ -1,5 +1,5 @@
 % Initialization
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 

--- a/examples/simulation/example_patternstim.m
+++ b/examples/simulation/example_patternstim.m
@@ -1,6 +1,6 @@
 % Minimal ParallelContext/IntFire1 example.
 % From from https://nrn.readthedocs.io/en/8.2.2/python/modelspec/programmatic/mechanisms/mech.html#PatternStim
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 soma = n.Section("soma");

--- a/examples/simulation/example_savestate.m
+++ b/examples/simulation/example_savestate.m
@@ -1,5 +1,5 @@
 % Initialization.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 soma = n.Section("soma");

--- a/examples/simulation/example_temptest.m
+++ b/examples/simulation/example_temptest.m
@@ -1,5 +1,5 @@
 % Minimal Exp3Syn/CVode/n.celcius example.
-clearvars -except test;  % Make sure testing params are not cleared.
+clearvars -except testCase;  % Make sure testing params are not cleared.
 n = neuron.Neuron();
 n.reset_sections();
 n.load_file('stdrun.hoc');

--- a/mac_matlab.sh
+++ b/mac_matlab.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export DYLD_LIBRARY_PATH='/Applications/MATLAB_R2022b.app/bin/maci64:/Applications/MATLAB_R2022b.app/sys/os/maci64:/Volumes/nobackup/kian.ohara/matlabneuroninterface/neuron/:/Users/kian.ohara/miniconda3/envs/neuron9/lib/python3.11/site-packages/neuron/.data/lib/:'$DYLD_LIBRARY_PATH
+echo $DYLD_LIBRARY_PATH
+
+matlab

--- a/mac_matlab.sh
+++ b/mac_matlab.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-export DYLD_LIBRARY_PATH='/Applications/MATLAB_R2022b.app/bin/maci64:/Applications/MATLAB_R2022b.app/sys/os/maci64:/Volumes/nobackup/kian.ohara/matlabneuroninterface/neuron/:/Users/kian.ohara/miniconda3/envs/neuron9/lib/python3.11/site-packages/neuron/.data/lib/:'$DYLD_LIBRARY_PATH
-echo $DYLD_LIBRARY_PATH
-
-matlab

--- a/neuron/.gitignore
+++ b/neuron/.gitignore
@@ -1,1 +1,1 @@
-neuronInterface.dll
+neuronInterface.*

--- a/setup.m
+++ b/setup.m
@@ -6,29 +6,31 @@ function setup()
     if ismac
         % Here just check if it is in DYLD_LIBRARY_PATH, you can't set it on
         % runtime in matlab.
-        NeuronInstallationDirectory = getenv('CONDA_PREFIX'); % equivalent to '/home/kian.ohara/.conda/envs/neuron9/';
+        NeuronInstallationDirectory = getenv('/Applications/nrn');
+
         % Check if NEURON directory is correct.
-        filename = fullfile(NeuronInstallationDirectory, 'bin', 'nrniv');
+        filename = fullfile(NeuronInstallationDirectory, 'lib', 'libnrniv.dylib');
 
-        assert(exist(filename, 'file') == 2, 'macOS needs to be started from a shell where the neuron binary (nrniv) declared in the DYLD_LIBRARY_PATH');
+        assert(exist(filename, 'file') == 2, 'macOS needs to be started from a shell where the neuron library (libnrniv.dylib) declared in the DYLD_LIBRARY_PATH');
         % All dependencies of the generated interface library must be findable.
-        % LINUX: Put them on the DYLD_LIBRARY_PATH
-        OSsyspathenv = 'DYLD_LIBRARY_PATH';
-
+        % MacOS: Put them on the DYLD_LIBRARY_PATH
+        assert((contains(fullfile(matlabroot, "bin", "maci64"), getenv(DYLD_LIBRARY_PATH))
+             && contains(fullfile(NeuronInstallationDirectory, "lib"), getenv(DYLD_LIBRARY_PATH))) == 2,
+             "The mex library and neuron installation directory are not on the DYLD_LIBRARY_PATH")
     elseif isunix
         % Here just check if it is in LD_LIBRARY_PATH, you can't set it on
         % runtime in matlab.
-        NeuronInstallationDirectory = getenv('CONDA_PREFIX'); % equivalent to '/home/kian.ohara/.conda/envs/neuron9/';
+        NeuronInstallationDirectory = getenv('/opt/nrn');
         % Check if NEURON directory is correct.
-        filename = fullfile(NeuronInstallationDirectory, 'bin', 'nrniv');
+        filename = fullfile(NeuronInstallationDirectory, 'lib', 'libnrniv.so');
 
-        assert(exist(filename, 'file') == 2, 'Linux needs to be started from a shell where the neuron binary (nrniv) declared in the LD_LIBRARY_PATH');
+        assert(exist(filename, 'file') == 2, 'Linux needs to be started from a shell where the neuron library (libnrniv.so) declared in the LD_LIBRARY_PATH');
         % All dependencies of the generated interface library must be findable.
         % LINUX: Put them on the LD_LIBRARY_PATH
-        OSsyspathenv = 'LD_LIBRARY_PATH';
+        assert((contains(fullfile(matlabroot, "bin", "glnxa64"), getenv(LD_LIBRARY_PATH))
+             && contains(fullfile(NeuronInstallationDirectory, "lib"), getenv(LD_LIBRARY_PATH))) == 2,
+             "The mex library and neuron installation directory are not on the LD_LIBRARY_PATH")
     elseif ispc
-        % Here just check if it is in LD_LIBRARY_PATH, you can't set it on
-        % runtime in matlab.
         NeuronInstallationDirectory = 'C:\nrn';
 
         % Check if NEURON directory is correct.

--- a/setup.m
+++ b/setup.m
@@ -4,22 +4,28 @@ function setup()
 
     % User setting:
     if ismac
-        disp('Mac not Supported ... yet');
+        % Here just check if it is in DYLD_LIBRARY_PATH, you can't set it on
+        % runtime in matlab.
+        NeuronInstallationDirectory = getenv('CONDA_PREFIX'); % equivalent to '/home/kian.ohara/.conda/envs/neuron9/';
+        % Check if NEURON directory is correct.
+        filename = fullfile(NeuronInstallationDirectory, 'bin', 'nrniv');
+
+        assert(exist(filename, 'file') == 2, 'macOS needs to be started from a shell where the neuron binary (nrniv) declared in the DYLD_LIBRARY_PATH');
+        % All dependencies of the generated interface library must be findable.
+        % LINUX: Put them on the DYLD_LIBRARY_PATH
+        OSsyspathenv = 'DYLD_LIBRARY_PATH';
+
     elseif isunix
         % Here just check if it is in LD_LIBRARY_PATH, you can't set it on
         % runtime in matlab.
-        NeuronInstallationDirectory = '/home/kian.ohara/.conda/envs/neuron9/';
+        NeuronInstallationDirectory = getenv('CONDA_PREFIX'); % equivalent to '/home/kian.ohara/.conda/envs/neuron9/';
         % Check if NEURON directory is correct.
         filename = fullfile(NeuronInstallationDirectory, 'bin', 'nrniv');
 
         assert(exist(filename, 'file') == 2, 'Linux needs to be started from a shell where the neuron binary (nrniv) declared in the LD_LIBRARY_PATH');
         % All dependencies of the generated interface library must be findable.
-        % LINUX: Put them on the PATH
-        dllpath = fullfile(NeuronInstallationDirectory, 'bin');
-        syspath = getenv('LD_LIBRARY_PATH');
-        if ~contains(string(syspath), string(dllpath)+pathsep)
-            setenv('LD_LIBRARY_PATH', [dllpath pathsep syspath]);
-        end
+        % LINUX: Put them on the LD_LIBRARY_PATH
+        OSsyspathenv = 'LD_LIBRARY_PATH';
     elseif ispc
         % Here just check if it is in LD_LIBRARY_PATH, you can't set it on
         % runtime in matlab.
@@ -31,11 +37,14 @@ function setup()
         assert(exist(filename, 'file') == 2, 'NEURON directory not found.');
         % All dependencies of the generated interface library must be findable.
         % WINDOWS: Put them on the PATH
+        OSsyspathenv='PATH';
+
         dllpath = fullfile(NeuronInstallationDirectory, 'bin');
-        syspath = getenv('PATH');
+        syspath = getenv(OSsyspathenv);
         if ~contains(string(syspath), string(dllpath)+pathsep)
-            setenv('PATH', [dllpath pathsep syspath]);
+            setenv(OSsyspathenv, [dllpath pathsep syspath]);
         end
+
     else
         disp('This platform not supported ... yet');
     end

--- a/setup.m
+++ b/setup.m
@@ -2,68 +2,77 @@
 % Run this function once to set up your Matlab session for Neuron interaction.
 function setup()
 
-    % User setting:
-    if ismac
-        % Here just check if it is in DYLD_LIBRARY_PATH, you can't set it on
-        % runtime in matlab.
-        NeuronInstallationDirectory = getenv('/Applications/nrn');
-
-        % Check if NEURON directory is correct.
-        filename = fullfile(NeuronInstallationDirectory, 'lib', 'libnrniv.dylib');
-
-        assert(exist(filename, 'file') == 2, 'macOS needs to be started from a shell where the neuron library (libnrniv.dylib) declared in the DYLD_LIBRARY_PATH');
-        % All dependencies of the generated interface library must be findable.
-        % MacOS: Put them on the DYLD_LIBRARY_PATH
-        assert((contains(fullfile(matlabroot, "bin", "maci64"), getenv(DYLD_LIBRARY_PATH))
-             && contains(fullfile(NeuronInstallationDirectory, "lib"), getenv(DYLD_LIBRARY_PATH))) == 2,
-             "The mex library and neuron installation directory are not on the DYLD_LIBRARY_PATH")
-    elseif isunix
-        % Here just check if it is in LD_LIBRARY_PATH, you can't set it on
-        % runtime in matlab.
-        NeuronInstallationDirectory = getenv('/opt/nrn');
-        % Check if NEURON directory is correct.
-        filename = fullfile(NeuronInstallationDirectory, 'lib', 'libnrniv.so');
-
-        assert(exist(filename, 'file') == 2, 'Linux needs to be started from a shell where the neuron library (libnrniv.so) declared in the LD_LIBRARY_PATH');
-        % All dependencies of the generated interface library must be findable.
-        % LINUX: Put them on the LD_LIBRARY_PATH
-        assert((contains(fullfile(matlabroot, "bin", "glnxa64"), getenv(LD_LIBRARY_PATH))
-             && contains(fullfile(NeuronInstallationDirectory, "lib"), getenv(LD_LIBRARY_PATH))) == 2,
-             "The mex library and neuron installation directory are not on the LD_LIBRARY_PATH")
-    elseif ispc
-        NeuronInstallationDirectory = 'C:\nrn';
-
-        % Check if NEURON directory is correct.
-        filename = fullfile(NeuronInstallationDirectory, 'bin', 'libnrniv.dll');
-
-        assert(exist(filename, 'file') == 2, 'NEURON directory not found.');
-        % All dependencies of the generated interface library must be findable.
-        % WINDOWS: Put them on the PATH
-        OSsyspathenv='PATH';
-
-        dllpath = fullfile(NeuronInstallationDirectory, 'bin');
-        syspath = getenv(OSsyspathenv);
-        if ~contains(string(syspath), string(dllpath)+pathsep)
-            setenv(OSsyspathenv, [dllpath pathsep syspath]);
-        end
-
-    else
-        disp('This platform not supported ... yet');
-    end
-
     % Path to the current directory.
     mlnrnpath = fileparts(mfilename('fullpath'));
     addpath(mlnrnpath);
 
     % Path to the generated interface library.
-    addpath(fullfile(mlnrnpath, 'neuron'));
+    addpath(utils.Paths.toolbox_lib_directory());
 
     % Path to example scripts.
-    addpath(fullfile(mlnrnpath, 'examples'));
-    addpath(fullfile(mlnrnpath, 'examples', 'basic_functionality'));
-    addpath(fullfile(mlnrnpath, 'examples', 'input'));
-    addpath(fullfile(mlnrnpath, 'examples', 'morphology'));
-    addpath(fullfile(mlnrnpath, 'examples', 'plotting'));
-    addpath(fullfile(mlnrnpath, 'examples', 'simulation'));
+    addpath(utils.Paths.examples_directory());
+    addpath(fullfile(utils.Paths.examples_directory(), 'basic_functionality'));
+    addpath(fullfile(utils.Paths.examples_directory(), 'input'));
+    addpath(fullfile(utils.Paths.examples_directory(), 'morphology'));
+    addpath(fullfile(utils.Paths.examples_directory(), 'plotting'));
+    addpath(fullfile(utils.Paths.examples_directory(), 'simulation'));
+
+    % Path to example scripts.
+    addpath(utils.Paths.examples_directory());
+
+    %  Check / set user-specific paths:
+    % Has neuron_lib_directory been set correctly in utils.Paths?
+    assert(exist(utils.Paths.libnrniv_file(), 'file') == 2, ...
+        'The shared library file libnrniv is not found at the expected location. Update neuron_lib_directory in +utils/Paths.m. Expected location based on neuron_lib_directory: %s', utils.Paths.libnrniv_file());
+
+    if ismac || isunix
+        if ismac
+            env_var = 'DYLD_LIBRARY_PATH';
+            mex_dir = fullfile(matlabroot, "bin", "maci64");
+        else
+            env_var = 'LD_LIBRARY_PATH';
+            mex_dir = fullfile(matlabroot, "bin", "glnxa64");
+        end
+
+        % All dependencies of the generated interface library must be
+        % findable. Check if the (DY)LD_LIBRARY_PATH is set correctly. It
+        % can't be set on runtime in matlab on unix and mac.
+        hasMex = contains(getenv(env_var), mex_dir);
+        hasNrn = contains(getenv(env_var), utils.Paths.neuron_lib_directory());
+        assert(hasMex && hasNrn, "The mex library directory and neuron installation library directory are not on the %s. Mex library directory: %s Neuron installation library directory: %s", env_var, mex_dir, utils.Paths.neuron_lib_directory())
+
+        % Use outofprocess execution, to avoid segmentation faults due to
+        % conflicts between the neuron shared libraries and matlabs shared
+        % libraries (mainly the libjvm that comes with matlab)
+        % Note: when Matlab's new javascript based desktop becomes the
+        % default, might be able to do inprocess also for Linux and Mac
+        try
+            % Do set outofprocess each time, because inprocess is the
+            % default, and outofprocess might not persist across Matlab
+            % versions.
+            clibConfiguration("neuron", ExecutionMode="outofprocess");
+        catch ME
+            if "MATLAB:CPP:InterfaceLibraryNotFound" == ME.identifier
+                % First time run, the neuron interface library has not been
+                % generated yet.
+            else
+                % An unexpected error
+                rethrow(ME)
+            end
+        end
+    elseif ispc
+        % All dependencies of the generated interface library must be
+        % findable. Add the directory with the NEURON libraries to the
+        % environments PATH 
+        env_var = 'PATH';
+
+        dllpath = utils.Paths.neuron_lib_directory();
+        syspath = getenv(env_var);
+        if ~contains(string(syspath), dllpath)
+            setenv(env_var, [dllpath pathsep syspath]);
+        end
+    else
+        disp('This platform not supported ... yet');
+    end
 
 end

--- a/setup.m
+++ b/setup.m
@@ -3,28 +3,51 @@
 function setup()
 
     % User setting:
-    NeuronInstallationDirectory  = 'C:\nrn';
+    if ismac
+        disp('Mac not Supported ... yet');
+    elseif isunix
+        % Here just check if it is in LD_LIBRARY_PATH, you can't set it on
+        % runtime in matlab.
+        NeuronInstallationDirectory = '/home/kian.ohara/.conda/envs/neuron9/';
+        % Check if NEURON directory is correct.
+        filename = fullfile(NeuronInstallationDirectory, 'bin', 'nrniv');
 
-    % Check if NEURON directory is correct.
-    filename = fullfile(NeuronInstallationDirectory , 'bin', 'libnrniv.dll');
-    assert(exist(filename, 'file') == 2, 'NEURON directory not found.');
-    
-    % All dependencies of the generated interface library must be findable.
-    % WINDOWS: Put them on the PATH
-    dllpath = fullfile(NeuronInstallationDirectory , 'bin');
-    syspath = getenv('PATH'); 
-    if ~contains(string(syspath), string(dllpath)+pathsep)
-        setenv('PATH', [dllpath pathsep syspath]);
+        assert(exist(filename, 'file') == 2, 'Linux needs to be started from a shell where the neuron binary (nrniv) declared in the LD_LIBRARY_PATH');
+        % All dependencies of the generated interface library must be findable.
+        % LINUX: Put them on the PATH
+        dllpath = fullfile(NeuronInstallationDirectory, 'bin');
+        syspath = getenv('LD_LIBRARY_PATH');
+        if ~contains(string(syspath), string(dllpath)+pathsep)
+            setenv('LD_LIBRARY_PATH', [dllpath pathsep syspath]);
+        end
+    elseif ispc
+        % Here just check if it is in LD_LIBRARY_PATH, you can't set it on
+        % runtime in matlab.
+        NeuronInstallationDirectory = 'C:\nrn';
+
+        % Check if NEURON directory is correct.
+        filename = fullfile(NeuronInstallationDirectory, 'bin', 'libnrniv.dll');
+
+        assert(exist(filename, 'file') == 2, 'NEURON directory not found.');
+        % All dependencies of the generated interface library must be findable.
+        % WINDOWS: Put them on the PATH
+        dllpath = fullfile(NeuronInstallationDirectory, 'bin');
+        syspath = getenv('PATH');
+        if ~contains(string(syspath), string(dllpath)+pathsep)
+            setenv('PATH', [dllpath pathsep syspath]);
+        end
+    else
+        disp('This platform not supported ... yet');
     end
-    
+
     % Path to the current directory.
     mlnrnpath = fileparts(mfilename('fullpath'));
     addpath(mlnrnpath);
-    
+
     % Path to the generated interface library.
     addpath(fullfile(mlnrnpath, 'neuron'));
-    
-    % Path to example scripts and tests.
+
+    % Path to example scripts.
     addpath(fullfile(mlnrnpath, 'examples'));
     addpath(fullfile(mlnrnpath, 'examples', 'basic_functionality'));
     addpath(fullfile(mlnrnpath, 'examples', 'input'));

--- a/source/neuron_dllimports.h
+++ b/source/neuron_dllimports.h
@@ -2,7 +2,7 @@
 #define NRNDLLIMP_H
 
 #include "neuron_api_headers.h"
-
+#ifdef _WIN32
 // Import C++ name mangled functions.
 __declspec(dllimport) vv_function delete_section;
 __declspec(dllimport) initer_function ivocmain_session;
@@ -78,6 +78,78 @@ extern "C" __declspec(dllimport) input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP
 const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP6_iobuf;
 extern "C" __declspec(dllimport) input_info_rs _Z21oc_restore_input_infoPKciiP6_iobuf;
 const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP6_iobuf;
+#else
+// Import C++ name mangled functions.
+extern vv_function delete_section;
+extern initer_function ivocmain_session;
+extern vsecptri_function mech_insert1;
+extern voptrsptritemptrptri_function new_sections;
+extern nptrsecptrd_function node_exact;
+extern vv_function nrnmpi_stubs;
+extern ppoptr_function ob2pntproc_0;
+extern cptrsecptr_function secname;
+extern vsecptr_function section_unref;
+extern vv_function simpleconnectsection;
+extern ivptr_function vector_capacity;
+extern dptrvptr_function vector_vec;
 
+// C++ name mangled nrn_* functions.
+extern dptrsecptrsptrd_function nrn_rangepointer;
+extern vsecptri_function nrn_change_nseg;
+extern vsecptrd_function nrn_length_change;
+extern vv_function nrn_popsec;
+extern vsecptr_function nrn_pushsec;
+extern secptrv_function nrn_sec_pop;
+
+// C++ name mangled hoc_* functions.
+extern dvptrint_function hoc_call_func;
+extern voptrsptri_function hoc_call_ob_proc;
+extern dsio_function hoc_call_objfunc;
+extern vsptr_function hoc_install_object_data_index;
+extern scptr_function hoc_lookup;
+extern optrsptri_function hoc_newobj1;
+extern voptr_function hoc_obj_ref;
+extern voptr_function hoc_obj_unref;
+extern optrptrv_function hoc_objpop;
+extern icptr_function hoc_oc;
+extern voptrptr_function hoc_pushobj;
+extern vdptr_function hoc_pushpx;
+extern vcptrptr_function hoc_pushstr;
+extern vd_function hoc_pushx;
+extern vv_function hoc_ret;
+extern cptrptrv_function hoc_strpop;
+extern scptrslptr_function hoc_table_lookup;
+extern voptrptr_function hoc_tobj_unref;
+extern dv_function hoc_xpop;
+
+// C++ name mangled oc_* functions.
+extern hoc_oop_ss oc_save_hoc_oop;
+extern hoc_oop_ss oc_restore_hoc_oop;
+extern cabcode_ss oc_save_cabcode;
+extern cabcode_ss oc_restore_cabcode;
+
+// Import non-name mangled functions and parameters.
+extern "C" void modl_reg(){};
+extern "C" int diam_changed;
+extern "C" Symlist* hoc_built_in_symlist;
+extern "C" Objectdata* hoc_objectdata;
+extern "C" Objectdata* hoc_top_level_data;
+extern "C" Symlist* hoc_top_level_symlist;
+extern "C" int nrn_is_python_extension;
+extern "C" int nrn_main_launch;
+extern "C" int nrn_nobanner_;
+extern "C" int nrn_try_catch_nest_depth;
+extern "C" vf2icif_function nrnpy_set_pr_etal;
+
+// Import functions for which name mangling goes awry.
+extern "C" code_ss _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+const auto oc_save_code = _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+extern "C" code_ss _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+const auto oc_restore_code = _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+extern "C" input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP8_IO_FILE;
+const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP8_IO_FILE;
+extern "C" input_info_rs _Z21oc_restore_input_infoPKciiP8_IO_FILE;
+const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP8_IO_FILE;
+#endif
 
 #endif

--- a/source/neuron_dllimports.h
+++ b/source/neuron_dllimports.h
@@ -78,7 +78,8 @@ extern "C" __declspec(dllimport) input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP
 const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP6_iobuf;
 extern "C" __declspec(dllimport) input_info_rs _Z21oc_restore_input_infoPKciiP6_iobuf;
 const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP6_iobuf;
-#else
+#elif __APPLE__ || __linux__
+//maybe change to #elif __linux__
 // Import C++ name mangled functions.
 extern vv_function delete_section;
 extern initer_function ivocmain_session;
@@ -141,6 +142,18 @@ extern "C" int nrn_nobanner_;
 extern "C" int nrn_try_catch_nest_depth;
 extern "C" vf2icif_function nrnpy_set_pr_etal;
 
+//maybe needs __linux__ or __APPLE__ variations
+#if __APPLE__
+// Import functions for which name mangling goes awry.
+extern "C" code_ss _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+const auto oc_save_code = _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+extern "C" code_ss _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+const auto oc_restore_code = _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+extern "C" input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP7__sFILE;
+const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP7__sFILE;
+extern "C" input_info_rs _Z21oc_restore_input_infoPKciiP7__sFILE;
+const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP7__sFILE;
+#elif __linux__
 // Import functions for which name mangling goes awry.
 extern "C" code_ss _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
 const auto oc_save_code = _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
@@ -150,6 +163,9 @@ extern "C" input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP8_IO_FILE;
 const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP8_IO_FILE;
 extern "C" input_info_rs _Z21oc_restore_input_infoPKciiP8_IO_FILE;
 const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP8_IO_FILE;
+#else
+#   error "Unknown compiler"
 #endif
 
+#endif
 #endif

--- a/source/neuron_dllimports.h
+++ b/source/neuron_dllimports.h
@@ -2,170 +2,115 @@
 #define NRNDLLIMP_H
 
 #include "neuron_api_headers.h"
+
 #ifdef _WIN32
-// Import C++ name mangled functions.
-__declspec(dllimport) vv_function delete_section;
-__declspec(dllimport) initer_function ivocmain_session;
-__declspec(dllimport) vsecptri_function mech_insert1;
-__declspec(dllimport) voptrsptritemptrptri_function new_sections;
-__declspec(dllimport) nptrsecptrd_function node_exact;
-__declspec(dllimport) vv_function nrnmpi_stubs;
-__declspec(dllimport) ppoptr_function ob2pntproc_0;
-__declspec(dllimport) cptrsecptr_function secname;
-__declspec(dllimport) vsecptr_function section_unref;
-__declspec(dllimport) vv_function simpleconnectsection;
-__declspec(dllimport) ivptr_function vector_capacity;
-__declspec(dllimport) dptrvptr_function vector_vec;
-
-// C++ name mangled nrn_* functions.
-__declspec(dllimport) dptrsecptrsptrd_function nrn_rangepointer;
-__declspec(dllimport) vsecptri_function nrn_change_nseg;
-__declspec(dllimport) vsecptrd_function nrn_length_change;
-__declspec(dllimport) vv_function nrn_popsec;
-__declspec(dllimport) vsecptr_function nrn_pushsec;
-__declspec(dllimport) secptrv_function nrn_sec_pop;
-
-// C++ name mangled hoc_* functions.
-__declspec(dllimport) dvptrint_function hoc_call_func;
-__declspec(dllimport) voptrsptri_function hoc_call_ob_proc;
-__declspec(dllimport) dsio_function hoc_call_objfunc;
-__declspec(dllimport) vsptr_function hoc_install_object_data_index;
-__declspec(dllimport) vitemptr_function hoc_l_delete;
-__declspec(dllimport) scptr_function hoc_lookup;
-__declspec(dllimport) optrsptri_function hoc_newobj1;
-__declspec(dllimport) voptr_function hoc_obj_ref;
-__declspec(dllimport) voptr_function hoc_obj_unref;
-__declspec(dllimport) optrptrv_function hoc_objpop;
-__declspec(dllimport) icptr_function hoc_oc;
-__declspec(dllimport) voptr_function hoc_push_object;
-__declspec(dllimport) vdptr_function hoc_pushpx;
-__declspec(dllimport) vsptr_function hoc_pushs;
-__declspec(dllimport) vcptrptr_function hoc_pushstr;
-__declspec(dllimport) vd_function hoc_pushx;
-__declspec(dllimport) dptrv_function hoc_pxpop;
-__declspec(dllimport) vv_function hoc_ret;
-__declspec(dllimport) cptrptrv_function hoc_strpop;
-__declspec(dllimport) scptrslptr_function hoc_table_lookup;
-__declspec(dllimport) voptrptr_function hoc_tobj_unref;
-__declspec(dllimport) dv_function hoc_xpop;
-
-// C++ name mangled oc_* functions.
-__declspec(dllimport) hoc_oop_ss oc_save_hoc_oop;
-__declspec(dllimport) hoc_oop_ss oc_restore_hoc_oop;
-__declspec(dllimport) cabcode_ss oc_save_cabcode;
-__declspec(dllimport) cabcode_ss oc_restore_cabcode;
-
-// Import non-name mangled functions and parameters.
-extern "C" __declspec(dllimport) int diam_changed;
-extern "C" __declspec(dllimport) int secondorder;
-extern "C" __declspec(dllimport) Symlist* hoc_built_in_symlist;
-extern "C" __declspec(dllimport) Objectdata* hoc_objectdata;
-extern "C" __declspec(dllimport) Objectdata* hoc_top_level_data;
-extern "C" __declspec(dllimport) Symlist* hoc_top_level_symlist;
-extern "C" __declspec(dllimport) int nrn_is_python_extension;
-extern "C" __declspec(dllimport) int nrn_main_launch;
-extern "C" __declspec(dllimport) int nrn_nobanner_;
-extern "C" __declspec(dllimport) int nrn_try_catch_nest_depth;
-extern "C" __declspec(dllimport) vf2icif_function nrnpy_set_pr_etal;
-extern "C" __declspec(dllimport) hoc_Item* section_list;
-
-// Import functions for which name mangling goes awry.
-extern "C" __declspec(dllimport) code_ss _Z12oc_save_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-const auto oc_save_code = _Z12oc_save_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-extern "C" __declspec(dllimport) code_ss _Z15oc_restore_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-const auto oc_restore_code = _Z15oc_restore_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-extern "C" __declspec(dllimport) input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP6_iobuf;
-const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP6_iobuf;
-extern "C" __declspec(dllimport) input_info_rs _Z21oc_restore_input_infoPKciiP6_iobuf;
-const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP6_iobuf;
+#define MANGLED __declspec(dllimport)
+#define NON_MANGLED extern "C" __declspec(dllimport)
 #elif __APPLE__ || __linux__
-//maybe change to #elif __linux__
+#define MANGLED extern
+#define NON_MANGLED extern "C"
+#else
+#   error "Unknown compiler / OS"
+#endif
+
 // Import C++ name mangled functions.
-extern vv_function delete_section;
-extern initer_function ivocmain_session;
-extern vsecptri_function mech_insert1;
-extern voptrsptritemptrptri_function new_sections;
-extern nptrsecptrd_function node_exact;
-extern vv_function nrnmpi_stubs;
-extern ppoptr_function ob2pntproc_0;
-extern cptrsecptr_function secname;
-extern vsecptr_function section_unref;
-extern vv_function simpleconnectsection;
-extern ivptr_function vector_capacity;
-extern dptrvptr_function vector_vec;
+MANGLED vv_function delete_section;
+MANGLED initer_function ivocmain_session;
+MANGLED vsecptri_function mech_insert1;
+MANGLED voptrsptritemptrptri_function new_sections;
+MANGLED nptrsecptrd_function node_exact;
+MANGLED vv_function nrnmpi_stubs;
+MANGLED ppoptr_function ob2pntproc_0;
+MANGLED cptrsecptr_function secname;
+MANGLED vsecptr_function section_unref;
+MANGLED vv_function simpleconnectsection;
+MANGLED ivptr_function vector_capacity;
+MANGLED dptrvptr_function vector_vec;
 
 // C++ name mangled nrn_* functions.
-extern dptrsecptrsptrd_function nrn_rangepointer;
-extern vsecptri_function nrn_change_nseg;
-extern vsecptrd_function nrn_length_change;
-extern vv_function nrn_popsec;
-extern vsecptr_function nrn_pushsec;
-extern secptrv_function nrn_sec_pop;
+MANGLED dptrsecptrsptrd_function nrn_rangepointer;
+MANGLED vsecptri_function nrn_change_nseg;
+MANGLED vsecptrd_function nrn_length_change;
+MANGLED vv_function nrn_popsec;
+MANGLED vsecptr_function nrn_pushsec;
+MANGLED secptrv_function nrn_sec_pop;
 
 // C++ name mangled hoc_* functions.
-extern dvptrint_function hoc_call_func;
-extern voptrsptri_function hoc_call_ob_proc;
-extern dsio_function hoc_call_objfunc;
-extern vsptr_function hoc_install_object_data_index;
-extern scptr_function hoc_lookup;
-extern optrsptri_function hoc_newobj1;
-extern voptr_function hoc_obj_ref;
-extern voptr_function hoc_obj_unref;
-extern optrptrv_function hoc_objpop;
-extern icptr_function hoc_oc;
-extern voptrptr_function hoc_pushobj;
-extern vdptr_function hoc_pushpx;
-extern vcptrptr_function hoc_pushstr;
-extern vd_function hoc_pushx;
-extern vv_function hoc_ret;
-extern cptrptrv_function hoc_strpop;
-extern scptrslptr_function hoc_table_lookup;
-extern voptrptr_function hoc_tobj_unref;
-extern dv_function hoc_xpop;
+MANGLED dvptrint_function hoc_call_func;
+MANGLED voptrsptri_function hoc_call_ob_proc;
+MANGLED dsio_function hoc_call_objfunc;
+MANGLED vsptr_function hoc_install_object_data_index;
+MANGLED vitemptr_function hoc_l_delete;
+MANGLED scptr_function hoc_lookup;
+MANGLED optrsptri_function hoc_newobj1;
+MANGLED voptr_function hoc_obj_ref;
+MANGLED voptr_function hoc_obj_unref;
+MANGLED optrptrv_function hoc_objpop;
+MANGLED icptr_function hoc_oc;
+MANGLED voptr_function hoc_push_object;
+MANGLED vdptr_function hoc_pushpx;
+MANGLED vsptr_function hoc_pushs;
+MANGLED vcptrptr_function hoc_pushstr;
+MANGLED vd_function hoc_pushx;
+MANGLED dptrv_function hoc_pxpop;
+MANGLED vv_function hoc_ret;
+MANGLED cptrptrv_function hoc_strpop;
+MANGLED scptrslptr_function hoc_table_lookup;
+MANGLED voptrptr_function hoc_tobj_unref;
+MANGLED dv_function hoc_xpop;
 
 // C++ name mangled oc_* functions.
-extern hoc_oop_ss oc_save_hoc_oop;
-extern hoc_oop_ss oc_restore_hoc_oop;
-extern cabcode_ss oc_save_cabcode;
-extern cabcode_ss oc_restore_cabcode;
+MANGLED hoc_oop_ss oc_save_hoc_oop;
+MANGLED hoc_oop_ss oc_restore_hoc_oop;
+MANGLED cabcode_ss oc_save_cabcode;
+MANGLED cabcode_ss oc_restore_cabcode;
 
 // Import non-name mangled functions and parameters.
-extern "C" void modl_reg(){};
-extern "C" int diam_changed;
-extern "C" Symlist* hoc_built_in_symlist;
-extern "C" Objectdata* hoc_objectdata;
-extern "C" Objectdata* hoc_top_level_data;
-extern "C" Symlist* hoc_top_level_symlist;
-extern "C" int nrn_is_python_extension;
-extern "C" int nrn_main_launch;
-extern "C" int nrn_nobanner_;
-extern "C" int nrn_try_catch_nest_depth;
-extern "C" vf2icif_function nrnpy_set_pr_etal;
+NON_MANGLED int diam_changed;
+NON_MANGLED int secondorder;
+NON_MANGLED Symlist* hoc_built_in_symlist;
+NON_MANGLED Objectdata* hoc_objectdata;
+NON_MANGLED Objectdata* hoc_top_level_data;
+NON_MANGLED Symlist* hoc_top_level_symlist;
+NON_MANGLED int nrn_is_python_extension;
+NON_MANGLED int nrn_main_launch;
+NON_MANGLED int nrn_nobanner_;
+NON_MANGLED int nrn_try_catch_nest_depth;
+NON_MANGLED vf2icif_function nrnpy_set_pr_etal;
+NON_MANGLED hoc_Item* section_list;
 
-//maybe needs __linux__ or __APPLE__ variations
-#if __APPLE__
+#ifdef _WIN32
 // Import functions for which name mangling goes awry.
-extern "C" code_ss _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+NON_MANGLED code_ss _Z12oc_save_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+const auto oc_save_code = _Z12oc_save_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+NON_MANGLED code_ss _Z15oc_restore_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+const auto oc_restore_code = _Z15oc_restore_codePP4InstS1_RyPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+NON_MANGLED input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP6_iobuf;
+const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP6_iobuf;
+NON_MANGLED input_info_rs _Z21oc_restore_input_infoPKciiP6_iobuf;
+const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP6_iobuf;
+#elif __APPLE__
+extern "C" void modl_reg(){};
+// Import functions for which name mangling goes awry.
+NON_MANGLED code_ss _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
 const auto oc_save_code = _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-extern "C" code_ss _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+NON_MANGLED code_ss _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
 const auto oc_restore_code = _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-extern "C" input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP7__sFILE;
+NON_MANGLED input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP7__sFILE;
 const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP7__sFILE;
-extern "C" input_info_rs _Z21oc_restore_input_infoPKciiP7__sFILE;
+NON_MANGLED input_info_rs _Z21oc_restore_input_infoPKciiP7__sFILE;
 const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP7__sFILE;
 #elif __linux__
+extern "C" void modl_reg(){};
 // Import functions for which name mangling goes awry.
-extern "C" code_ss _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+NON_MANGLED code_ss _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
 const auto oc_save_code = _Z12oc_save_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-extern "C" code_ss _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
+NON_MANGLED code_ss _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
 const auto oc_restore_code = _Z15oc_restore_codePP4InstS1_RmPPN3nrn2oc5frameEPiS8_S1_S7_S2_PP7SymlistS1_S8_;
-extern "C" input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP8_IO_FILE;
+NON_MANGLED input_info_ss _Z18oc_save_input_infoPPKcPiS2_PP8_IO_FILE;
 const auto oc_save_input_info = _Z18oc_save_input_infoPPKcPiS2_PP8_IO_FILE;
-extern "C" input_info_rs _Z21oc_restore_input_infoPKciiP8_IO_FILE;
+NON_MANGLED input_info_rs _Z21oc_restore_input_infoPKciiP8_IO_FILE;
 const auto oc_restore_input_info = _Z21oc_restore_input_infoPKciiP8_IO_FILE;
-#else
-#   error "Unknown compiler"
 #endif
 
-#endif
 #endif

--- a/source/nrnmatlab.h
+++ b/source/nrnmatlab.h
@@ -83,7 +83,7 @@ __declspec(dllimport) Section* nrn_sec_pop(void);
 __declspec(dllimport) void section_unref(Section*);
 __declspec(dllimport) void simpleconnectsection(void);
 __declspec(dllimport) char* secname(Section*);
-#else
+#elif __APPLE__ || __linux__
 extern Node* node_exact(Section*, double);
 extern void nrn_pushsec(Section* sec);
 extern void hoc_obj_unref(Object*);
@@ -103,6 +103,8 @@ extern Section* nrn_sec_pop(void);
 extern void section_unref(Section*);
 extern void simpleconnectsection(void);
 extern char* secname(Section*);
+#else
+#   error "Unknown compiler"
 #endif
 
 // Pointer class for MATLAB interface.

--- a/source/nrnmatlab.h
+++ b/source/nrnmatlab.h
@@ -61,51 +61,37 @@ void set_secondorder(int);
 int get_secondorder(void);
 
 // C++ Neuron functions directly accessible from MATLAB.
-#if _WIN32
-__declspec(dllimport) Node* node_exact(Section*, double);
-__declspec(dllimport) void nrn_pushsec(Section* sec);
-__declspec(dllimport) void hoc_obj_unref(Object*);
-__declspec(dllimport) double hoc_call_func(Symbol*, int);
-__declspec(dllimport) void hoc_call_ob_proc(Object*, Symbol*, int);
-__declspec(dllimport) Symbol* hoc_lookup(const char*);
-__declspec(dllimport) void hoc_push_object(Object*);
-__declspec(dllimport) void hoc_pushx(double);
-__declspec(dllimport) Symbol* hoc_table_lookup(const char*, Symlist*);
-__declspec(dllimport) double hoc_xpop(void);
-__declspec(dllimport) int hoc_oc(const char*);
-__declspec(dllimport) void hoc_l_delete(hoc_Item*);
-__declspec(dllimport) void delete_section(void);
-__declspec(dllimport) Object* hoc_newobj1(Symbol*, int);
-__declspec(dllimport) void nrn_change_nseg(Section*, int);
-__declspec(dllimport) void nrn_length_change(Section*, double);
-__declspec(dllimport) void mech_insert1(Section*, int);
-__declspec(dllimport) Section* nrn_sec_pop(void);
-__declspec(dllimport) void section_unref(Section*);
-__declspec(dllimport) void simpleconnectsection(void);
-__declspec(dllimport) char* secname(Section*);
+#ifdef _WIN32
+#define MANGLED __declspec(dllimport)
+#define NON_MANGLED extern "C" __declspec(dllimport)
 #elif __APPLE__ || __linux__
-extern Node* node_exact(Section*, double);
-extern void nrn_pushsec(Section* sec);
-extern void hoc_obj_unref(Object*);
-extern double hoc_call_func(Symbol*, int);
-extern void hoc_call_ob_proc(Object*, Symbol*, int);
-extern Symbol* hoc_lookup(const char*);
-extern void hoc_pushx(double);
-extern Symbol* hoc_table_lookup(const char*, Symlist*);
-extern double hoc_xpop(void);
-extern int hoc_oc(const char*);
-extern void delete_section(void);
-extern Object* hoc_newobj1(Symbol*, int);
-extern void nrn_change_nseg(Section*, int);
-extern void nrn_length_change(Section*, double);
-extern void mech_insert1(Section*, int);
-extern Section* nrn_sec_pop(void);
-extern void section_unref(Section*);
-extern void simpleconnectsection(void);
-extern char* secname(Section*);
+#define MANGLED extern
+#define NON_MANGLED extern "C"
 #else
-#   error "Unknown compiler"
+#   error "Unknown compiler / OS"
 #endif
+
+MANGLED Node* node_exact(Section*, double);
+MANGLED void nrn_pushsec(Section* sec);
+MANGLED void hoc_obj_unref(Object*);
+MANGLED double hoc_call_func(Symbol*, int);
+MANGLED void hoc_call_ob_proc(Object*, Symbol*, int);
+MANGLED Symbol* hoc_lookup(const char*);
+MANGLED void hoc_push_object(Object*);
+MANGLED void hoc_pushx(double);
+MANGLED Symbol* hoc_table_lookup(const char*, Symlist*);
+MANGLED double hoc_xpop(void);
+MANGLED int hoc_oc(const char*);
+MANGLED void hoc_l_delete(hoc_Item*);
+MANGLED void delete_section(void);
+MANGLED Object* hoc_newobj1(Symbol*, int);
+MANGLED void nrn_change_nseg(Section*, int);
+MANGLED void nrn_length_change(Section*, double);
+MANGLED void mech_insert1(Section*, int);
+MANGLED Section* nrn_sec_pop(void);
+MANGLED void section_unref(Section*);
+MANGLED void simpleconnectsection(void);
+MANGLED char* secname(Section*);
 
 // Pointer class for MATLAB interface.
 class NrnRef { /* Holds a pointer to a double. */

--- a/source/nrnmatlab.h
+++ b/source/nrnmatlab.h
@@ -61,6 +61,7 @@ void set_secondorder(int);
 int get_secondorder(void);
 
 // C++ Neuron functions directly accessible from MATLAB.
+#if _WIN32
 __declspec(dllimport) Node* node_exact(Section*, double);
 __declspec(dllimport) void nrn_pushsec(Section* sec);
 __declspec(dllimport) void hoc_obj_unref(Object*);
@@ -82,6 +83,27 @@ __declspec(dllimport) Section* nrn_sec_pop(void);
 __declspec(dllimport) void section_unref(Section*);
 __declspec(dllimport) void simpleconnectsection(void);
 __declspec(dllimport) char* secname(Section*);
+#else
+extern Node* node_exact(Section*, double);
+extern void nrn_pushsec(Section* sec);
+extern void hoc_obj_unref(Object*);
+extern double hoc_call_func(Symbol*, int);
+extern void hoc_call_ob_proc(Object*, Symbol*, int);
+extern Symbol* hoc_lookup(const char*);
+extern void hoc_pushx(double);
+extern Symbol* hoc_table_lookup(const char*, Symlist*);
+extern double hoc_xpop(void);
+extern int hoc_oc(const char*);
+extern void delete_section(void);
+extern Object* hoc_newobj1(Symbol*, int);
+extern void nrn_change_nseg(Section*, int);
+extern void nrn_length_change(Section*, double);
+extern void mech_insert1(Section*, int);
+extern Section* nrn_sec_pop(void);
+extern void section_unref(Section*);
+extern void simpleconnectsection(void);
+extern char* secname(Section*);
+#endif
 
 // Pointer class for MATLAB interface.
 class NrnRef { /* Holds a pointer to a double. */


### PR DESCRIPTION
Update the code with switches, where necessary, to support windows and mac and linux.

Mainly in setup and buildinterface, and some cpp header files, different paths need to be followed for different operating systems.

Closes #17 
Nearly all of #18, except for one last step that is blocking correct execution on mac.