### PR TITLE
Nrnref properties

### DIFF
--- a/+neuron/NrnRef.m
+++ b/+neuron/NrnRef.m
@@ -107,6 +107,8 @@ classdef NrnRef < handle
                     [varargout{1:nargout}] = builtin('subsref', self, S(1:2));
                     n_processed = 2;
                 % Are we trying to directly access a class property?
+                elseif strcmp(S(1).subs, "ref") || strcmp(S(1).subs, "ref_class") || strcmp(S(1).subs, "length")
+                    error("Property '%s' is for display only and cannot be accessed directly.", S(1).subs);
                 elseif isprop(self, S(1).subs)
                     [varargout{1:nargout}] = self.(S(1).subs);
                     n_processed = 1;

--- a/+neuron/Session.m
+++ b/+neuron/Session.m
@@ -358,5 +358,29 @@ classdef Session < dynamicprops
             % Wrap in SectionArray for consistent behavior
             all_sections = neuron.SectionArray(sections_cell);
         end
+        function dist = distance(sec1, x1, sec2, x2)
+        % Calculate distance between two points in space, given by sections sec1 and sec2 and
+        % positions x1 and x2 (in [0, 1] range).
+        %   dist = distance(sec1, x1, sec2, x2)
+            if nargin < 4
+                if nargin == 2
+                    % If only two arguments, assume both are segments and extract section and position
+                    if isa(sec1, 'neuron.Segment') && isa(x1, 'neuron.Segment')
+                        sec2 = x1.parent_sec;
+                        x2 = x1.x;
+                        x1 = sec1.x;
+                        sec1 = sec1.parent_sec;
+                    else
+                        error("If only two arguments are provided, both must be neuron.Segment objects.");
+                    end
+                else
+                    error("Incorrect number of arguments. Provide two sections and their positions.");
+                end
+            end
+            if ~isa(sec1, 'neuron.Section') || ~isa(sec2, 'neuron.Section')
+                error("Both sec1 and sec2 must be neuron.Section objects.");
+            end
+            dist = neuron_api('nrn_distance', sec1.sec, x1, sec2.sec, x2);
+        end
     end
 end

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -121,6 +121,8 @@ const char* (*nrn_get_plotshape_varname_)(ShapePlotInterface*) = nullptr;
 float (*nrn_get_plotshape_low_)(ShapePlotInterface*) = nullptr;
 float (*nrn_get_plotshape_high_)(ShapePlotInterface*) = nullptr;
 
+double (*nrn_distance_)(Section*, double, Section*, double) = nullptr;
+
 bool has_inited = false;
 DLL_HANDLE neuron_handle = nullptr;
 std::unordered_map<std::string, void(*)(const mxArray**, mxArray**)> function_map;
@@ -1477,6 +1479,17 @@ void nrn_prop_exists(const mxArray* prhs[], mxArray* plhs[]) {
     plhs[0] = mxCreateLogicalScalar(result);
 }
 
+void nrn_distance(const mxArray* prhs[], mxArray* plhs[]) {
+    auto sec0_ptr = static_cast<uint64_t>(mxGetScalar(prhs[1]));
+    Section* sec0 = reinterpret_cast<Section*>(sec0_ptr);
+    double x0 = mxGetScalar(prhs[2]);
+    auto sec1_ptr = static_cast<uint64_t>(mxGetScalar(prhs[3]));
+    Section* sec1 = reinterpret_cast<Section*>(sec1_ptr);
+    double x1 = mxGetScalar(prhs[4]);    
+    double dist = nrn_distance_(sec0, x0, sec1, x1);
+    plhs[0] = mxCreateDoubleScalar(dist);
+}
+
 
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
@@ -1702,6 +1715,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         function_map["nrn_sectionlist_iterator_done"] = nrn_sectionlist_iterator_done;
         nrn_prop_exists_ = (bool (*)(const Object*)) DLL_GET_PROC(neuron_handle, "nrn_prop_exists");
         function_map["nrn_prop_exists"] = nrn_prop_exists;
+        nrn_distance_ = (double (*)(Section*, double, Section*, double)) DLL_GET_PROC(neuron_handle, "nrn_distance");
+        function_map["nrn_distance"] = nrn_distance;
 
         if (!nrn_cas_) {
              mexErrMsgIdAndTxt("NEURON:OutdatedAPI",


### PR DESCRIPTION
Made `NrnRef` properties (`ref`, `ref_class`, and `length`) display-only, non-accessible to prevent inconsistencies or unwanted behavior. Previously, trying to access said properties for Vector-refs (or any refs of length > 1) did not work because the `isprop` check to check if the `subsref` input string is an actual property returned a logical array of all 0s. Internally, `nargout` for `subsref` in these cases is always set to the length and that can't be bypassed (and `nargout` can't be set manually), so the closest I got was to set every element in the `varargout` array of size `nargout` to that property string, but then it would be printed to the output screen `nargout` times. So after a lot of different approaches and attempts, I decided to make those properties display-only with an error when trying to access them. Something like `ref_class` ("Vector" or "Section," for example) does not have to be directly accessible in my opinion. This way it is also consistent. But open to other thoughts.