### PR TITLE
Allow multiple strings

### DIFF
--- a/+neuron/+stack/hoc_pop.m
+++ b/+neuron/+stack/hoc_pop.m
@@ -4,7 +4,7 @@ function value = hoc_pop(returntype)
     if (returntype=="double")
         value = neuron_api('nrn_double_pop');
     elseif (returntype=="string" || returntype=="char")
-        value = neuron_api('nrn_pop_str');
+        value = neuron_api('nrn_str_pop');
     elseif (returntype=="ref")
         % For NrnRef objects.
         value = neuron_api('nrn_double_ptr_pop');

--- a/+neuron/+stack/hoc_push.m
+++ b/+neuron/+stack/hoc_push.m
@@ -1,12 +1,22 @@
-function hoc_push(value)
+function hoc_push(value, varargin)
 % Push a double, string, Vector, Object or NrnRef to the NEURON stack.
 %   hoc_push(value)
+%   hoc_push(value, string_stack)
+    string_stack = [];
+    if nargin >= 2
+        string_stack = varargin{1};
+    end
+    
     if isa(value, "logical")
         neuron_api('nrn_double_push', double(value));
     elseif isa(value, "double")
         neuron_api('nrn_double_push', value);
     elseif isa(value, "string") || isa(value, "char")
-        neuron_api('nrn_str_push', value);
+        if isempty(string_stack)
+            neuron_api('nrn_str_push', value);
+        else
+            neuron_api('nrn_str_push', string_stack, value);
+        end
     elseif isa(value, "neuron.Object")
         neuron_api('nrn_object_push', value.obj);
     elseif isa(value, "neuron.NrnRef")

--- a/+neuron/+stack/hoc_push.m
+++ b/+neuron/+stack/hoc_push.m
@@ -1,10 +1,9 @@
-function hoc_push(value, varargin)
+function hoc_push(value, string_stack)
 % Push a double, string, Vector, Object or NrnRef to the NEURON stack.
 %   hoc_push(value)
 %   hoc_push(value, string_stack)
-    string_stack = [];
-    if nargin >= 2
-        string_stack = varargin{1};
+    if nargin < 2
+        string_stack = [];
     end
     
     if isa(value, "logical")

--- a/+neuron/+stack/push_args.m
+++ b/+neuron/+stack/push_args.m
@@ -1,11 +1,23 @@
 function [nsecs, nargs] = push_args(varargin)
 % Push cell array of arguments to the NEURON stack; return pushed number of 
 % sections nsecs and pushed number of function arguments nargs.
-%   [nsecs, nargs] = push_args(varargin)
+%   [nsecs, nargs] = push_args(args...)
+%   [nsecs, nargs] = push_args(args..., string_stack)
+    
+    % Check if last argument is a string_stack (uint64 pointer)
+    string_stack = [];
+    args = varargin;
+    
+    if nargin > 0 && isa(varargin{end}, 'uint64') && numel(varargin{end}) == 1
+        % Last argument might be string_stack
+        string_stack = varargin{end};
+        args = varargin(1:end-1);
+    end
+    
     nargs = 0;
     nsecs = 0;
-    for i=1:length(varargin)
-        arg = varargin{i};
+    for i=1:length(args)
+        arg = args{i};
         if (isa(arg, "neuron.Section"))
             % Push just a Section to the Section stack.
             nsecs = nsecs + 1;
@@ -18,7 +30,7 @@ function [nsecs, nargs] = push_args(varargin)
         else
             % Push an argument to the NEURON stack.
             nargs = nargs + 1;
-            neuron.stack.hoc_push(arg);
+            neuron.stack.hoc_push(arg, string_stack);
         end
     end
 end

--- a/+neuron/NrnRef.m
+++ b/+neuron/NrnRef.m
@@ -19,7 +19,7 @@ classdef NrnRef < handle
                 error('Invalid input for NrnRef constructor.');
             end
             self.obj = obj;
-            disp(obj);
+            % disp(obj);
         end
         function value = get(self, ind)
         % Get value.

--- a/+neuron/Object.m
+++ b/+neuron/Object.m
@@ -92,10 +92,13 @@ classdef Object < dynamicprops
         function value = call_method_hoc(self, method, returntype, varargin)
         % Call method by passing method name (method) to HOC lookup, along with its return type (returntype) and method arguments (varargin).
         %   value = call_method_double(method, varargin)
-            persistent string_stack
-            if isempty(string_stack)
-                string_stack = neuron_api('nrn_create_string_stack');
+            % Create cell array of string stacks to account for nested calls
+            persistent string_stacks
+            if isempty(string_stacks)
+                string_stacks = {};
             end
+            stack = neuron_api('nrn_create_string_stack');
+            string_stacks{end + 1} = stack;
             try
                 if self.objtype == "Matrix"
                     if method == "getval" || ...
@@ -148,7 +151,7 @@ classdef Object < dynamicprops
                         end
                     end
                 end
-                [nsecs, nargs] = neuron.stack.push_args(varargin{:}, string_stack);
+                [nsecs, nargs] = neuron.stack.push_args(varargin{:}, stack);
                 sym = neuron_api('nrn_method_symbol', self.obj, method);
                 neuron_api('nrn_method_call', self.obj, sym, nargs);
                 if ~strcmp(returntype, 'none')
@@ -163,13 +166,16 @@ classdef Object < dynamicprops
                     end
                 end
             catch e
-                neuron_api('nrn_reset_string_stack', string_stack);  % Cleanup on error
+                neuron_api('nrn_reset_string_stack', stack);  % Cleanup on error
+                string_stacks(end) = [];  % pop
                 warning(e.message);
                 warning("'"+string(method)+"': caught error during call to NEURON function.");
                 value = NaN;
                 % state.restore();
             end
-            neuron_api('nrn_reset_string_stack', string_stack);  % Final cleanup
+            % End function by popping last frame in cell array
+            neuron_api('nrn_reset_string_stack', stack);
+            string_stacks(end) = [];
 
         end
 

--- a/+neuron/Session.m
+++ b/+neuron/Session.m
@@ -234,12 +234,15 @@ classdef Session < dynamicprops
         % Call function by passing function name (func) to HOC lookup, along with its return type (returntype) and arguments (varargin).
         %   value = call_func_hoc(func, returntype, varargin)
 
-            % h = neuron_api('nrn_create_string_stack');  % Create new string stack
+            persistent string_stack
+            if isempty(string_stack)
+                string_stack = neuron_api('nrn_create_string_stack');
+            end
             try
-                [nsecs, nargs] = neuron.stack.push_args(varargin{:});
+                [nsecs, nargs] = neuron.stack.push_args(varargin{:}, string_stack);
                 neuron_api('nrn_function_call', func, nargs);
                 value = neuron.stack.hoc_pop(returntype);
-                neuron.stack.pop_sections(nsecs);
+                % neuron.stack.pop_sections(nsecs);
                 
             catch e
                 % neuron_api('nrn_clear_string_stack', h);

--- a/+neuron/Session.m
+++ b/+neuron/Session.m
@@ -234,25 +234,30 @@ classdef Session < dynamicprops
         % Call function by passing function name (func) to HOC lookup, along with its return type (returntype) and arguments (varargin).
         %   value = call_func_hoc(func, returntype, varargin)
 
-            persistent string_stack
-            if isempty(string_stack)
-                string_stack = neuron_api('nrn_create_string_stack');
+            % Create cell array of string stacks to account for nested calls
+            persistent string_stacks
+            if isempty(string_stacks)
+                string_stacks = {};
             end
+
+            stack = neuron_api('nrn_create_string_stack');
+            string_stacks{end + 1} = stack;
+
             try
-                [nsecs, nargs] = neuron.stack.push_args(varargin{:}, string_stack);
+                [nsecs, nargs] = neuron.stack.push_args(varargin{:}, stack);
                 neuron_api('nrn_function_call', func, nargs);
                 value = neuron.stack.hoc_pop(returntype);
                 neuron.stack.pop_sections(nsecs);
-                
             catch e
-                neuron_api('nrn_reset_string_stack', string_stack);  % Cleanup on error
-                value = NaN;
+                neuron_api('nrn_reset_string_stack', stack);  % cleanup
+                string_stacks(end) = [];  % pop
                 warning(e.message);
                 error("'"+string(func)+"': caught error during call to NEURON function.");
-                % state.restore();
             end
-            neuron_api('nrn_reset_string_stack', string_stack);  % Final cleanup
-
+            % End function by popping last frame in cell array
+            neuron_api('nrn_reset_string_stack', stack);
+            string_stacks(end) = [];
+            
         end
         function obj = hoc_new_obj(objtype, varargin)
         % Make object by providing object type (objtype) and constructor arguments (varargin).

--- a/+neuron/Session.m
+++ b/+neuron/Session.m
@@ -245,13 +245,13 @@ classdef Session < dynamicprops
                 neuron.stack.pop_sections(nsecs);
                 
             catch e
-                % neuron_api('nrn_clear_string_stack', h);
+                neuron_api('nrn_reset_string_stack', string_stack);  % Cleanup on error
                 value = NaN;
                 warning(e.message);
                 error("'"+string(func)+"': caught error during call to NEURON function.");
                 % state.restore();
             end
-            %neuron_api('nrn_clear_string_stack', h);  % Final cleanup
+            neuron_api('nrn_reset_string_stack', string_stack);  % Final cleanup
 
         end
         function obj = hoc_new_obj(objtype, varargin)

--- a/+neuron/Session.m
+++ b/+neuron/Session.m
@@ -234,17 +234,21 @@ classdef Session < dynamicprops
         % Call function by passing function name (func) to HOC lookup, along with its return type (returntype) and arguments (varargin).
         %   value = call_func_hoc(func, returntype, varargin)
 
+            % h = neuron_api('nrn_create_string_stack');  % Create new string stack
             try
                 [nsecs, nargs] = neuron.stack.push_args(varargin{:});
                 neuron_api('nrn_function_call', func, nargs);
                 value = neuron.stack.hoc_pop(returntype);
                 neuron.stack.pop_sections(nsecs);
+                
             catch e
+                % neuron_api('nrn_clear_string_stack', h);
                 value = NaN;
                 warning(e.message);
                 error("'"+string(func)+"': caught error during call to NEURON function.");
                 % state.restore();
             end
+            %neuron_api('nrn_clear_string_stack', h);  % Final cleanup
 
         end
         function obj = hoc_new_obj(objtype, varargin)

--- a/+neuron/Session.m
+++ b/+neuron/Session.m
@@ -258,8 +258,7 @@ classdef Session < dynamicprops
                     obj = neuron.Vector(cppobj);
                     vector_data = varargin{:};
                     for i=1:numel(vector_data)
-                        temp = obj.append(vector_data(i));
-                        clear temp;
+                        obj.append(vector_data(i));
                     end
                 elseif (objtype == "SectionList")
                     % Accept cell array or list of neuron.Section objects

--- a/+neuron/Session.m
+++ b/+neuron/Session.m
@@ -242,7 +242,7 @@ classdef Session < dynamicprops
                 [nsecs, nargs] = neuron.stack.push_args(varargin{:}, string_stack);
                 neuron_api('nrn_function_call', func, nargs);
                 value = neuron.stack.hoc_pop(returntype);
-                % neuron.stack.pop_sections(nsecs);
+                neuron.stack.pop_sections(nsecs);
                 
             catch e
                 % neuron_api('nrn_clear_string_stack', h);

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -96,7 +96,7 @@ bool (*nrn_prop_exists_)(const Object*) = nullptr;
 double* (*nrn_vector_data_)(Object*) = nullptr;
 
 // --- Stack and pointer functions ---
-char** (*nrn_pop_str_)(void) = nullptr;
+char** (*nrn_str_pop_)(void) = nullptr;
 Object* (*nrn_object_pop_)(void) = nullptr;
 double* (*nrn_double_ptr_pop_)(void) = nullptr;
 void (*nrn_str_push_)(char**) = nullptr;
@@ -651,8 +651,8 @@ void nrn_section_pop(const mxArray* prhs[], mxArray* plhs[]) {
     nrn_section_pop_();
 }
 
-void nrn_pop_str(const mxArray* prhs[], mxArray* plhs[]) {
-    char** result = nrn_pop_str_();
+void nrn_str_pop(const mxArray* prhs[], mxArray* plhs[]) {
+    char** result = nrn_str_pop_();
     plhs[0] = mxCreateString(*result);
 }
 
@@ -1023,7 +1023,7 @@ void nrnref_get_name(const mxArray* prhs[], mxArray* plhs[]) {
     if (ref->ref_class == NrnRef::RefClass::Vector) {
         // For Vectors, call label function to get the name
         nrn_method_call_(ref->obj, nrn_method_symbol_(ref->obj, "label"), 0);
-        char** result = nrn_pop_str_();
+        char** result = nrn_str_pop_();
         plhs[0] = mxCreateString(*result);
     }
     else {
@@ -1466,8 +1466,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         function_map["nrn_vector_data"] = nrn_vector_data;
         nrn_section_pop_ = (void (*)(void)) DLL_GET_PROC(neuron_handle, "nrn_section_pop");
         function_map["nrn_section_pop"] = nrn_section_pop;
-        nrn_pop_str_ = (char** (*)(void)) DLL_GET_PROC(neuron_handle, "nrn_pop_str");
-        function_map["nrn_pop_str"] = nrn_pop_str;
+        nrn_str_pop_ = (char** (*)(void)) DLL_GET_PROC(neuron_handle, "nrn_str_pop");
+        function_map["nrn_str_pop"] = nrn_str_pop;
         nrn_object_pop_ = (Object* (*)(void)) DLL_GET_PROC(neuron_handle, "nrn_object_pop");
         function_map["nrn_object_pop"] = nrn_object_pop;
         nrn_str_push_ = (void (*)(char**)) DLL_GET_PROC(neuron_handle, "nrn_str_push");

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -664,25 +664,50 @@ void nrn_object_pop(const mxArray* prhs[], mxArray* plhs[]) {
 
 void nrn_create_string_stack(const mxArray*[], mxArray* plhs[]) {
     auto* stack = new std::vector<char*>();
-    mexPrintf("Creating stack: %p\n", stack);  // debug
     plhs[0] = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
     *((uint64_t*)mxGetData(plhs[0])) = reinterpret_cast<uint64_t>(stack);
 }
 
 void nrn_str_push(const mxArray* prhs[], mxArray* plhs[]) {
+    // Handle two cases:
+    // Case 1: nrn_str_push(value) - no string stack, use the old static method
+    // Case 2: nrn_str_push(string_stack, value) - use string stack
+    
+    if (prhs[1] == nullptr || mxGetNumberOfElements(prhs[1]) != 1 || !mxIsUint64(prhs[1])) {
+        // Case 1: No string_stack provided, use simple static approach
+        
+        static char* str = nullptr;
+        static std::string temp_str;
+        temp_str = getStringFromMxArray(prhs[1]);
+        str = const_cast<char*>(temp_str.c_str());
+        nrn_str_push_(&str);
+        return;
+    }
+    
+    // Case 2: string_stack provided
     auto* stack = reinterpret_cast<std::vector<char*>*>(
         *((uint64_t*)mxGetData(prhs[1])));
-    mexPrintf("Using stack: %p\n", stack);
 
-    static char* str = nullptr;
-    static std::string temp_str;
-    temp_str = getStringFromMxArray(prhs[2]);
-    str = const_cast<char*>(temp_str.c_str());
-
-    mexPrintf("Pushing string: %s\n", str);
-
-    nrn_str_push_(&str);     // push pointer to NEURON
-    stack->push_back(str);   // keep it alive until cleared
+    // Create a new string for each push (no static variables!)
+    std::string temp_str = getStringFromMxArray(prhs[2]);
+    
+    // Allocate new memory for this specific string
+    char* str = new char[temp_str.length() + 1];
+    std::strcpy(str, temp_str.c_str());
+    
+    // Reserve enough space upfront to prevent reallocation during push operations
+    if (stack->capacity() < stack->size() + 1) {
+        stack->reserve(stack->size() + 20);
+    }
+    
+    // Add to our stack to keep it alive
+    stack->push_back(str);
+    
+    // Get the index of the element we just added
+    size_t index = stack->size() - 1;
+    
+    // Pass pointer to the element at this specific index
+    nrn_str_push_(&((*stack)[index]));
 }
 
 /* void nrn_str_push(const mxArray* prhs[], mxArray* plhs[]) {

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -77,12 +77,10 @@ int (*nrn_symbol_array_length_)(Symbol*) = nullptr;
 void (*nrn_symbol_push_)(Symbol*) = nullptr;
 
 // --- HOC/Function registration and calling ---
-Symbol* (*hoc_install_)(const char*, int, double, Symlist**) = nullptr;
 void (*nrn_register_function_)(void (*)(), const char*, int type) = nullptr;
 char* (*nrn_gargstr_)(int) = nullptr;
 void (*nrn_hoc_ret_)(void) = nullptr;
 double (*hoc_xpop_)(void) = nullptr;
-void (*hoc_call_ob_proc_)(Object*, Symbol*, int) = nullptr;
 void (*nrn_function_call_)(Symbol* sym, int narg) = nullptr;
 void (*nrn_hoc_call_)(char const* command) = nullptr;
 
@@ -584,15 +582,6 @@ void nrn_method_symbol(const mxArray* prhs[], mxArray* plhs[]) {
     // Return the Symbol* by casting to uint64
     plhs[0] = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
     *(uint64_t*)mxGetData(plhs[0]) = reinterpret_cast<uint64_t>(method_sym);
-}
-
-void nrn_hoc_call_ob_proc(const mxArray* prhs[], mxArray* plhs[]) {
-    auto obj_ptr = static_cast<uint64_t>(mxGetScalar(prhs[1]));
-    Object* obj = reinterpret_cast<Object*>(obj_ptr);
-    auto sym_ptr = static_cast<uint64_t>(mxGetScalar(prhs[2]));
-    Symbol* sym = reinterpret_cast<Symbol*>(sym_ptr);
-    auto [narg] = extractParams<int>(prhs, 3);
-    hoc_call_ob_proc_(obj, sym, narg);
 }
 
 void nrn_get_value(const mxArray* prhs[], mxArray* plhs[]) {
@@ -1451,7 +1440,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         nrn_symbol_type_ = (int (*)(const Symbol*)) DLL_GET_PROC(neuron_handle, "nrn_symbol_type");
         nrn_symbol_subtype_ = (int (*)(const Symbol*)) DLL_GET_PROC(neuron_handle, "nrn_symbol_subtype");
         nrn_symbol_name_ = (char const* (*)(const Symbol*)) DLL_GET_PROC(neuron_handle, "nrn_symbol_name");
-        hoc_install_ = (Symbol* (*)(const char*, int, double, Symlist**)) DLL_GET_PROC(neuron_handle, "hoc_install");
         nrn_register_function_ = (void (*)(void (*)(), const char*, int)) DLL_GET_PROC(neuron_handle, "nrn_register_function");
         nrn_gargstr_ = (char* (*)(int)) DLL_GET_PROC(neuron_handle, "nrn_gargstr");  // TODO get rid of name mangling
         nrn_hoc_ret_ = (void (*)(void)) DLL_GET_PROC(neuron_handle, "nrn_hoc_ret");  // TODO get rid of name mangling
@@ -1469,8 +1457,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         function_map["get_class_methods"] = get_class_methods;
         nrn_method_symbol_ = (Symbol* (*)(Object*, char const* const)) DLL_GET_PROC(neuron_handle, "nrn_method_symbol");
         function_map["nrn_method_symbol"] = nrn_method_symbol;
-        hoc_call_ob_proc_ = (void (*)(Object*, Symbol*, int)) DLL_GET_PROC(neuron_handle, "hoc_call_ob_proc");
-        function_map["nrn_hoc_call_ob_proc"] = nrn_hoc_call_ob_proc;
         function_map["nrn_get_value"] = nrn_get_value;
         nrn_symbol_dataptr_ = (double* (*)(Symbol*)) DLL_GET_PROC(neuron_handle, "nrn_symbol_dataptr");
         function_map["nrn_set_value"] = nrn_set_value;

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -664,21 +664,39 @@ void nrn_object_pop(const mxArray* prhs[], mxArray* plhs[]) {
 
 void nrn_create_string_stack(const mxArray*[], mxArray* plhs[]) {
     auto* stack = new std::vector<char*>();
+    mexPrintf("Creating stack: %p\n", stack);  // debug
     plhs[0] = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
     *((uint64_t*)mxGetData(plhs[0])) = reinterpret_cast<uint64_t>(stack);
 }
 
 void nrn_str_push(const mxArray* prhs[], mxArray* plhs[]) {
     auto* stack = reinterpret_cast<std::vector<char*>*>(
-        *((uint64_t*)mxGetData(prhs[0])));  // Handle passed in
+        *((uint64_t*)mxGetData(prhs[1])));
+    mexPrintf("Using stack: %p\n", stack);
 
-    std::string temp_str = getStringFromMxArray(prhs[1]);
-    char* str = new char[temp_str.size() + 1];
-    std::strcpy(str, temp_str.c_str());
-    nrn_str_push_(&str);
+    static char* str = nullptr;
+    static std::string temp_str;
+    temp_str = getStringFromMxArray(prhs[2]);
+    str = const_cast<char*>(temp_str.c_str());
 
-    stack->push_back(str);  // Track in this instance
+    mexPrintf("Pushing string: %s\n", str);
+
+    nrn_str_push_(&str);     // push pointer to NEURON
+    stack->push_back(str);   // keep it alive until cleared
 }
+
+/* void nrn_str_push(const mxArray* prhs[], mxArray* plhs[]) {
+    // This is a memory leak and we can only have one string at a time on the stack
+    // Allocate a static buffer to hold the string pointer
+    static char* str = nullptr;
+    static std::string temp_str;
+    temp_str = getStringFromMxArray(prhs[1]);
+    str = const_cast<char*>(temp_str.c_str());
+    nrn_str_push_(&str);
+    // Do not call mxFree(str); here!
+}
+*/
+
 
 void nrn_clear_string_stack(const mxArray* prhs[], mxArray*[]) {
     auto* stack = reinterpret_cast<std::vector<char*>*>(


### PR DESCRIPTION
`nrn_create_string_stack`: Allocates a persistent C++ std::vector<char*> to hold dynamically allocated strings. Returns the pointer as a uint64 handle to MATLAB.
`nrn_str_push`: Now Accepts either a single string (legacy behavior) or a string stack handle + string. In the latter case:
Allocates a new C-style string (new char[]) for each input. Stores it in the `string_stack` to keep it alive during the HOC function call. Pushes the string pointer to NEURON using `nrn_str_push_`.
`nrn_reset_string_stack`: Frees all dynamically allocated strings in the stack and clears it. Called after each HOC function call to prevent memory leaks.
In MATLAB, `call_func_hoc` maintains a persistent `string_stack` to avoid recreating the stack on every call. Resets the stack (frees memory) after each invocation