### PR TITLE
Added additional exception handling to neuron_api.cpp to prevent crashes on of mex on windows

### DIFF
--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -539,7 +539,13 @@ void create_FInitializeHandler(const mxArray* prhs[], mxArray* plhs[]) {
 void nrn_function_call(const mxArray* prhs[], mxArray* plhs[]) {
     auto [name, narg] = extractParams<std::string, int>(prhs, 1);
     auto sym = nrn_symbol_(name.c_str());
-    nrn_function_call_(sym, narg);
+    try {
+        nrn_function_call_(sym, narg);// this can cause unhandled exceptions crashing mex/MATLAB
+    }
+    catch (...) {
+         mexErrMsgIdAndTxt("neuron_api:unknown_exception", "Unknown exception caught in nrn_function_call");
+    }
+    
 }
 
 void nrn_object_new(const mxArray* prhs[], mxArray* plhs[]) {
@@ -637,7 +643,12 @@ void nrn_method_call(const mxArray* prhs[], mxArray* plhs[]) {
     auto sym_ptr = static_cast<uint64_t>(mxGetScalar(prhs[2]));
     Symbol* method_sym = reinterpret_cast<Symbol*>(sym_ptr);
     int narg = (int) mxGetScalar(prhs[3]);
-    nrn_method_call_(obj, method_sym, narg);
+    try {
+    nrn_method_call_(obj, method_sym, narg); // this can cause unhandled exceptions crashing mex/MATLAB
+    }
+    catch (...) {
+        mexErrMsgIdAndTxt("neuron_api:unknown_exception", "Unknown exception caught in nrn_method_call");
+    }
 }
 
 void nrn_vector_data(const mxArray* prhs[], mxArray* plhs[]) {

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -644,7 +644,7 @@ void nrn_method_call(const mxArray* prhs[], mxArray* plhs[]) {
     Symbol* method_sym = reinterpret_cast<Symbol*>(sym_ptr);
     int narg = (int) mxGetScalar(prhs[3]);
     try {
-    nrn_method_call_(obj, method_sym, narg); // this can cause unhandled exceptions crashing mex/MATLAB
+        nrn_method_call_(obj, method_sym, narg); // this can cause unhandled exceptions crashing mex/MATLAB
     }
     catch (...) {
         mexErrMsgIdAndTxt("neuron_api:unknown_exception", "Unknown exception caught in nrn_method_call");

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <limits>
 
+
 #ifdef _WIN32
     #include <windows.h>
     #define DLL_HANDLE HMODULE
@@ -92,6 +93,7 @@ char* (*nrn_gargstr_)(int) = nullptr;
 void (*nrn_hoc_ret_)(void) = nullptr;
 double (*hoc_xpop_)(void) = nullptr;
 void (*nrn_function_call_)(Symbol* sym, int narg) = nullptr;
+int (*nrn_function_call_nothrow_)(Symbol* sym, int narg, char*, size_t) = nullptr;
 void (*nrn_hoc_call_)(char const* command) = nullptr;
 
 // --- Object-related functions ---
@@ -100,6 +102,7 @@ void (*nrn_object_unref_)(Object*) = nullptr;
 char const* (*nrn_class_name_)(const Object*) = nullptr;
 Symbol* (*nrn_method_symbol_)(Object*, char const* const) = nullptr;
 void (*nrn_method_call_)(Object*, Symbol*, int) = nullptr;
+int (*nrn_method_call_nothrow_)(Object*, Symbol*, int, char*, size_t) = nullptr;
 bool (*nrn_prop_exists_)(const Object*) = nullptr;
 
 // --- Vector-related functions ---
@@ -537,15 +540,15 @@ void create_FInitializeHandler(const mxArray* prhs[], mxArray* plhs[]) {
 
 
 void nrn_function_call(const mxArray* prhs[], mxArray* plhs[]) {
+    char error_buffer[256];
     auto [name, narg] = extractParams<std::string, int>(prhs, 1);
     auto sym = nrn_symbol_(name.c_str());
     try {
-        nrn_function_call_(sym, narg);// this can cause unhandled exceptions crashing mex/MATLAB
+        int returnval = nrn_function_call_nothrow_(sym, narg, error_buffer, sizeof(error_buffer));
     }
     catch (...) {
-         mexErrMsgIdAndTxt("neuron_api:unknown_exception", "Unknown exception caught in nrn_function_call");
+        mexErrMsgIdAndTxt("neuron_api:exception", "nrn_function_call failed: %s\n", error_buffer);
     }
-    
 }
 
 void nrn_object_new(const mxArray* prhs[], mxArray* plhs[]) {
@@ -638,16 +641,17 @@ void nrn_set_value(const mxArray* prhs[], mxArray* plhs[]) {
 }
 
 void nrn_method_call(const mxArray* prhs[], mxArray* plhs[]) {
+    char error_buffer[256];
     auto obj_ptr = static_cast<uint64_t>(mxGetScalar(prhs[1]));
     Object* obj = reinterpret_cast<Object*>(obj_ptr);
     auto sym_ptr = static_cast<uint64_t>(mxGetScalar(prhs[2]));
     Symbol* method_sym = reinterpret_cast<Symbol*>(sym_ptr);
     int narg = (int) mxGetScalar(prhs[3]);
     try {
-        nrn_method_call_(obj, method_sym, narg); // this can cause unhandled exceptions crashing mex/MATLAB
+        int returnval = nrn_method_call_nothrow_(obj, method_sym, narg, error_buffer, sizeof(error_buffer));
     }
     catch (...) {
-        mexErrMsgIdAndTxt("neuron_api:unknown_exception", "Unknown exception caught in nrn_method_call");
+        mexErrMsgIdAndTxt("neuron_api:exception", "nrn_method_call failed: %s\n", error_buffer);
     }
 }
 
@@ -1088,12 +1092,18 @@ void nrnref_get_n_elements(const mxArray* prhs[], mxArray* plhs[]) {
 }
 
 void nrnref_get_name(const mxArray* prhs[], mxArray* plhs[]) {
+    char error_buffer[256];
     auto ref_ptr = static_cast<uint64_t>(mxGetScalar(prhs[1]));
     NrnRef* ref = reinterpret_cast<NrnRef*>(ref_ptr);
 
     if (ref->ref_class == NrnRef::RefClass::Vector) {
-        // For Vectors, call label function to get the name
-        nrn_method_call_(ref->obj, nrn_method_symbol_(ref->obj, "label"), 0);
+            // For Vectors, call label function to get the name
+        try {
+            int returnval = nrn_method_call_nothrow_(ref->obj, nrn_method_symbol_(ref->obj, "label"), 0, error_buffer, sizeof(error_buffer));
+        }
+        catch (...) {
+            mexErrMsgIdAndTxt("neuron_api:exception", "nrnref_get_name failed: %s\n", error_buffer);
+        }
         char** result = nrn_str_pop_();
         plhs[0] = mxCreateString(*result);
     }
@@ -1518,7 +1528,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         nrn_register_function_ = (void (*)(void (*)(), const char*, int)) DLL_GET_PROC(neuron_handle, "nrn_register_function");
         nrn_gargstr_ = (char* (*)(int)) DLL_GET_PROC(neuron_handle, "nrn_gargstr");  // TODO get rid of name mangling
         nrn_hoc_ret_ = (void (*)(void)) DLL_GET_PROC(neuron_handle, "nrn_hoc_ret");  // TODO get rid of name mangling
-        nrn_function_call_ = (void(*)(Symbol*,int)) DLL_GET_PROC(neuron_handle, "nrn_function_call");
+        nrn_function_call_ = (void (*)(Symbol *, int))DLL_GET_PROC(neuron_handle, "nrn_function_call");
+        nrn_function_call_nothrow_ = (int (*)(Symbol *, int, char *, size_t))DLL_GET_PROC(neuron_handle, "nrn_function_call_nothrow"); // HERE
         function_map["nrn_function_call"] = nrn_function_call;
         nrn_double_pop_ = (double (*)(void)) DLL_GET_PROC(neuron_handle, "nrn_double_pop");
         function_map["nrn_double_pop"] = nrn_double_pop;
@@ -1535,7 +1546,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         function_map["nrn_get_value"] = nrn_get_value;
         nrn_symbol_dataptr_ = (double* (*)(Symbol*)) DLL_GET_PROC(neuron_handle, "nrn_symbol_dataptr");
         function_map["nrn_set_value"] = nrn_set_value;
-        nrn_method_call_ = (void (*)(Object*, Symbol*, int)) DLL_GET_PROC(neuron_handle, "nrn_method_call");
+        nrn_method_call_ = (void (*)(Object *, Symbol *, int))DLL_GET_PROC(neuron_handle, "nrn_method_call");
+        nrn_method_call_nothrow_ = (int (*)(Object *, Symbol *, int, char *, size_t))DLL_GET_PROC(neuron_handle, "nrn_method_call_nothrow");
         function_map["nrn_method_call"] = nrn_method_call;
         nrn_vector_data_ = (double* (*)(Object*)) DLL_GET_PROC(neuron_handle, "nrn_vector_data");
         function_map["nrn_vector_data"] = nrn_vector_data;
@@ -1690,4 +1702,3 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         }
     }
 }
-

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <cstdint>
 #include <cstring>
-
+#include <limits>
 
 #ifdef _WIN32
     #include <windows.h>

--- a/source/neuron_api.cpp
+++ b/source/neuron_api.cpp
@@ -543,10 +543,8 @@ void nrn_function_call(const mxArray* prhs[], mxArray* plhs[]) {
     char error_buffer[256];
     auto [name, narg] = extractParams<std::string, int>(prhs, 1);
     auto sym = nrn_symbol_(name.c_str());
-    try {
-        int returnval = nrn_function_call_nothrow_(sym, narg, error_buffer, sizeof(error_buffer));
-    }
-    catch (...) {
+    int returnval = nrn_function_call_nothrow_(sym, narg, error_buffer, sizeof(error_buffer));
+    if (returnval) {
         mexErrMsgIdAndTxt("neuron_api:exception", "nrn_function_call failed: %s\n", error_buffer);
     }
 }
@@ -647,10 +645,8 @@ void nrn_method_call(const mxArray* prhs[], mxArray* plhs[]) {
     auto sym_ptr = static_cast<uint64_t>(mxGetScalar(prhs[2]));
     Symbol* method_sym = reinterpret_cast<Symbol*>(sym_ptr);
     int narg = (int) mxGetScalar(prhs[3]);
-    try {
-        int returnval = nrn_method_call_nothrow_(obj, method_sym, narg, error_buffer, sizeof(error_buffer));
-    }
-    catch (...) {
+    int returnval = nrn_method_call_nothrow_(obj, method_sym, narg, error_buffer, sizeof(error_buffer));
+    if (returnval) {
         mexErrMsgIdAndTxt("neuron_api:exception", "nrn_method_call failed: %s\n", error_buffer);
     }
 }
@@ -1098,10 +1094,8 @@ void nrnref_get_name(const mxArray* prhs[], mxArray* plhs[]) {
 
     if (ref->ref_class == NrnRef::RefClass::Vector) {
             // For Vectors, call label function to get the name
-        try {
-            int returnval = nrn_method_call_nothrow_(ref->obj, nrn_method_symbol_(ref->obj, "label"), 0, error_buffer, sizeof(error_buffer));
-        }
-        catch (...) {
+        int returnval = nrn_method_call_nothrow_(ref->obj, nrn_method_symbol_(ref->obj, "label"), 0, error_buffer, sizeof(error_buffer));
+        if (returnval) {
             mexErrMsgIdAndTxt("neuron_api:exception", "nrnref_get_name failed: %s\n", error_buffer);
         }
         char** result = nrn_str_pop_();


### PR DESCRIPTION
I added two try/catch statements in nrn_method_call and nrn_function_call in source/neuron_api.cpp to prevent crashes that occur to me (for example, running example_crash) caused by unhandled exceptions in mex on windows.

I also added a missing include that prevented compilation on windows in source/neuron_api.cpp.

This branch is based on "windows-support" branch as changes already made there are prerequisite for compiling on windows.



THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY.